### PR TITLE
Update promote task

### DIFF
--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -67,7 +67,6 @@
             "options": {
                 "alpha": "Alpha",
                 "beta": "Beta",
-                "production": "Production",
                 "rollout": "Rollout"
             }
         },
@@ -79,7 +78,6 @@
             "required": true,
             "helpMarkDown": "The track you wish to promote to.",
             "options": {
-                "alpha": "Alpha",
                 "beta": "Beta",
                 "production": "Production",
                 "rollout": "Rollout"


### PR DESCRIPTION
This PR simply updates the source and destination track fields to reflect reality, since you can't promote an APK to the `alpha` track or from the `production` track.