### PR TITLE
Fix spaces in path

### DIFF
--- a/Tasks/google-play-release/GooglePlay.js
+++ b/Tasks/google-play-release/GooglePlay.js
@@ -109,7 +109,7 @@ function tryGetPackageName(apkFile) {
         packageName = apkParser
             .readFile(apkFile)
             .readManifestSync()
-        .package;
+            .package;
 
         tl.debug("name extraction from apk succeeded: " + packageName);
     }
@@ -260,8 +260,26 @@ function resolveGlobPath(path) {
         }
     }
 
+    return fixSpacesInPath(path);
+}
+
+/**
+ * Adjusts the path string to properly escape spaces
+ * @param {string} path - path to fix
+ * @return {string} path - path with spaces fixed if needed
+ */
+function fixSpacesInPath(path) {
+    if (path.indexOf(" ") >= 0) {
+        if (process.platform === "win32") {
+            return `"${path}"`;
+        } else {
+            return path.replace(/ /g, "\\ ");
+        }
+    }
+    
     return path;
 }
+
 
 // Future features:
 // ----------------

--- a/Tasks/google-play-release/GooglePlay.js
+++ b/Tasks/google-play-release/GooglePlay.js
@@ -258,10 +258,12 @@ function resolveGlobPath(path) {
         if (filesList.length > 0) {
             path = filesList[0];
         }
+
+        // VSTS tries to be smart when passing in paths with spaces in them by quoting the whole path. Unfortunately, this actually breaks everything, so remove them here.
+        return path.replace(/\"/g, "");
     }
 
-    // VSTS tries to be smart when passing in paths with spaces in them by quoting the whole path. Unfortunately, this actually breaks everything, so remove them here.
-    return path.replace(/\"/g, "");
+    return path;
 }
 
 

--- a/Tasks/google-play-release/GooglePlay.js
+++ b/Tasks/google-play-release/GooglePlay.js
@@ -260,24 +260,8 @@ function resolveGlobPath(path) {
         }
     }
 
-    return fixSpacesInPath(path);
-}
-
-/**
- * Adjusts the path string to properly escape spaces
- * @param {string} path - path to fix
- * @return {string} path - path with spaces fixed if needed
- */
-function fixSpacesInPath(path) {
-    if (path.indexOf(" ") >= 0) {
-        if (process.platform === "win32") {
-            return `"${path}"`;
-        } else {
-            return path.replace(/ /g, "\\ ");
-        }
-    }
-    
-    return path;
+    // VSTS tries to be smart when passing in paths with spaces in them by quoting the whole path. Unfortunately, this actually breaks everything, so remove them here.
+    return path.replace(/\"/g, "");
 }
 
 


### PR DESCRIPTION
VSTS tries to be smart when passing back paths with spaces in them by wrapping them in quotes.
Unfortunately, the backend package we use to parse the apks was already smart about this, so the extra quotes were being considered as part of the path instead of as wrappers around the path.
This caused the path resolution to break, which caused apk parsing to fail.

Fix is to remove these extra quotes when we resolve the glob paths.

@lostintangent @shishirx34 @geof90 