### PR TITLE
Multiple apk fix assign to track

### DIFF
--- a/Tasks/google-play-release/GooglePlay.js
+++ b/Tasks/google-play-release/GooglePlay.js
@@ -304,18 +304,19 @@ function addAllChangelogs(languageCode, directory) {
         });
 
         var versionCodeFound = false;
-        changelogs.forEach(function(changeLogFile) {
-            var changelogVersion = path.basename(changelogFile).replace(/\.[^/.]+$/g, "");
+        changelogs.forEach(function(changelogFile) {
+            var changelogName = path.basename(changelogFile, path.extname(changelogFile));
+            var changelogVersion = parseInt(changelogName, 10);
             if (apkVersionCodes.indexOf(changelogVersion) == -1) {
                 tl.debug(`File ${changelogFile} is not a valid version code`);
-                continue;
+                return;
             }
 
             versionCodeFound = true;
-            var fullChangelogPath = path.join(changelogDir, changelogs[i]);
+            var fullChangelogPath = path.join(changelogDir, changelogFile);
             addAllChangelogsPromise = addAllChangelogsPromise.then(function (changelog) {
                 console.log(`Appending changelog ${changelog}`);
-                return addChangelog.bind(this, languageCode, changelog)();
+                return addChangelog.bind(this, languageCode, changelog, changelogVersion)();
             }.bind(this, fullChangelogPath));
         });
 

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "1",
         "Minor": "2",
-        "Patch": "2"
+        "Patch": "3"
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [
@@ -96,7 +96,7 @@
             "helpMarkDown": "Path to the file specifying the release notes for the APK you are publishing."
         },
         {
-            "name": "shouldAttachMetadata", 
+            "name": "shouldAttachMetadata",
             "type": "boolean",
             "label": "Update Metadata",
             "defaultValue": false,

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
 	"manifestVersion": 1.0,
 	"id": "google-play",
 	"name": "Google Play",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"publisher": "ms-vsclient",
 	"description": "Provides build/release tasks that enable performing continuous delivery to the Google Play store from an automated VSTS build or release definition",
 	"categories": [


### PR DESCRIPTION
Properly assigning APK to track using its version code
Properly set version code when updating recent changes, based on change log file name