### PR TITLE
Fixing image path for screenshots folders

### DIFF
--- a/Tasks/google-play-release/GooglePlay.js
+++ b/Tasks/google-play-release/GooglePlay.js
@@ -590,7 +590,8 @@ function getImageList(directory) {
                         if (!shouldAttemptUpload) {
                             console.log(`Stat returned that ${imageType} was not a directory. Is there a file that shares this name?`);
                         } else {
-                            imageList[imageType] = fs.readdirSync(fullPathToDirToCheck).filter(function (image) {
+                            imageList[imageType] = fs.readdirSync(fullPathToDirToCheck)
+                            .filter(function (image) {
                                 var pathIsFile = false;
                                 try {
                                     pathIsFile = fs.statSync(path.join(fullPathToDirToCheck, image)).isFile();
@@ -600,6 +601,9 @@ function getImageList(directory) {
                                 }
 
                                 return pathIsFile;
+                            })
+                            .map(function (image) {
+                                return path.join(fullPathToDirToCheck, image);
                             });
                         }
                     }

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "1",
         "Minor": "2",
-        "Patch": "3"
+        "Patch": "4"
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
 	"manifestVersion": 1.0,
 	"id": "google-play",
 	"name": "Google Play",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"publisher": "ms-vsclient",
 	"description": "Provides build/release tasks that enable performing continuous delivery to the Google Play store from an automated VSTS build or release definition",
 	"categories": [


### PR DESCRIPTION
Fixing image upload [issue](https://github.com/Microsoft/google-play-vsts-extension/issues/29), getImageList not returning full path to image file.