### PR TITLE
Add typings@2.0.0 as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "tfx-cli": "^0.3.40",
     "tslint": "^3.15.1",
     "typescript": "1.8.7",
+    "typings": "2.0.0",
     "validator": "3.33.0",
     "yargs": "^6.4.0"
   }


### PR DESCRIPTION
Cloning, running npm install and then 'gulp' would fail if typings@2.0.0 is not installed.  Make it a local dependency so it 'just works'.  (This check is found at https://github.com/Microsoft/google-play-vsts-extension/blob/master/make.js#L107)