### PR TITLE
Add support for internal test track

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ![Build Status](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/5350/badge?branch=master)
 
-This extension contains a set of deployment tasks which allow you to automate the release, promotion and rollout of app updates to the Google Play store from your CI environment. This can reduce the effort needed to keep your alpha, beta, rollout and production deployments up-to-date, since you can simply push changes to the configured source control branches, and let your automated build take care of the rest.
+This extension contains a set of deployment tasks which allow you to automate the release, promotion and rollout of app updates to the Google Play store from your CI environment. This can reduce the effort needed to keep your internal test, alpha, beta, rollout and production deployments up-to-date, since you can simply push changes to the configured source control branches, and let your automated build take care of the rest.
 
 ## Prerequisites
 

--- a/Tasks/google-play-promote/google-play-promote.ts
+++ b/Tasks/google-play-promote/google-play-promote.ts
@@ -144,7 +144,7 @@ function getNewEdit(edits: any, globalParams: GlobalParams, packageName: string)
  * Gets information for the specified app and track
  * Assumes authorized
  * @param {string} packageName - unique android package name (com.android.etc)
- * @param {string} track - one of the values {"alpha", "beta", "production", "rollout"}
+ * @param {string} track - one of the values {"internal", "alpha", "beta", "production", "rollout"}
  * @returns {Promise} track - A promise that will return result from updating a track
  *                            { track: string, versionCodes: [integer], userFraction: double }
  */
@@ -164,7 +164,7 @@ function getTrack(edits: any, packageName: string, track: string): Promise<any> 
  * Update a given release track with the given information
  * Assumes authorized
  * @param {string} packageName - unique android package name (com.android.etc)
- * @param {string} track - one of the values {"alpha", "beta", "production", "rollout"}
+ * @param {string} track - one of the values {"internal", "alpha", "beta", "production", "rollout"}
  * @param {integer or [integers]} versionCode - version code returned from an apk call. will take either a number or a [number]
  * @param {double} userFraction - for rollout, fraction of users to get update
  * @returns {Promise} track - A promise that will return result from updating a track

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "130",
+        "Minor": "135",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "129",
+        "Minor": "130",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
@@ -61,10 +61,11 @@
             "name": "sourceTrack",
             "type": "pickList",
             "label": "Source Track",
-            "defaultValue": "alpha",
+            "defaultValue": "internal",
             "required": true,
             "helpMarkDown": "The track you wish to promote from.",
             "options": {
+                "internal": "Internal test",
                 "alpha": "Alpha",
                 "beta": "Beta",
                 "rollout": "Rollout"
@@ -78,6 +79,7 @@
             "required": true,
             "helpMarkDown": "The track you wish to promote to.",
             "options": {
+                "alpha": "Alpha",
                 "beta": "Beta",
                 "production": "Production",
                 "rollout": "Rollout"

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -13,7 +13,7 @@
         "npm"
     ],
     "version": {
-        "Major": "1",
+        "Major": "2",
         "Minor": "135",
         "Patch": "0"
     },

--- a/Tasks/google-play-promote/task.loc.json
+++ b/Tasks/google-play-promote/task.loc.json
@@ -13,7 +13,7 @@
     "npm"
   ],
   "version": {
-    "Major": "1",
+    "Major": "2",
     "Minor": "135",
     "Patch": "0"
   },

--- a/Tasks/google-play-promote/task.loc.json
+++ b/Tasks/google-play-promote/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "130",
+    "Minor": "135",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-promote/task.loc.json
+++ b/Tasks/google-play-promote/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "129",
+    "Minor": "130",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",
@@ -61,10 +61,11 @@
       "name": "sourceTrack",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.sourceTrack",
-      "defaultValue": "alpha",
+      "defaultValue": "internal",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.sourceTrack",
       "options": {
+        "internal": "Internal test",
         "alpha": "Alpha",
         "beta": "Beta",
         "rollout": "Rollout"
@@ -78,6 +79,7 @@
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.destinationTrack",
       "options": {
+        "alpha": "Alpha",
         "beta": "Beta",
         "production": "Production",
         "rollout": "Rollout"

--- a/Tasks/google-play-release/GooglePlay.ts
+++ b/Tasks/google-play-release/GooglePlay.ts
@@ -290,7 +290,7 @@ async function addApk(edits: any, packageName: string, apkFile: string, APK_MIME
  * Update a given release track with the given information
  * Assumes authorized
  * @param {string} packageName unique android package name (com.android.etc)
- * @param {string} track one of the values {"alpha", "beta", "production", "rollout"}
+ * @param {string} track one of the values {"internal", "alpha", "beta", "production", "rollout"}
  * @param {number[]} apkVersionCodes version code of uploaded modules.
  * @param {string} versionCodeListType type of version code replacement filter, i.e. 'all', 'list', or 'expression'
  * @param {string | string[]} versionCodeFilter version code filter, i.e. either a list of version code or a regular expression string.

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "129",
+        "Minor": "130",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
@@ -68,12 +68,13 @@
             "name": "track",
             "type": "pickList",
             "label": "Track",
-            "defaultValue": "alpha",
+            "defaultValue": "internal",
             "required": true,
             "helpMarkDown": "Track you want to publish the APK to.",
             "options": {
+                "internal": "Internal test",
                 "alpha": "Alpha",
-                "beta": "Beta",
+                "beta": "Beta",            
                 "production": "Production",
                 "rollout": "Rollout"
             }

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "130",
+        "Minor": "135",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -13,7 +13,7 @@
         "npm"
     ],
     "version": {
-        "Major": "1",
+        "Major": "2",
         "Minor": "135",
         "Patch": "0"
     },

--- a/Tasks/google-play-release/task.loc.json
+++ b/Tasks/google-play-release/task.loc.json
@@ -13,7 +13,7 @@
     "npm"
   ],
   "version": {
-    "Major": "1",
+    "Major": "2",
     "Minor": "135",
     "Patch": "0"
   },

--- a/Tasks/google-play-release/task.loc.json
+++ b/Tasks/google-play-release/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "129",
+    "Minor": "130",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",
@@ -68,10 +68,11 @@
       "name": "track",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.track",
-      "defaultValue": "alpha",
+      "defaultValue": "internal",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.track",
       "options": {
+        "internal": "Internal test",
         "alpha": "Alpha",
         "beta": "Beta",
         "production": "Production",

--- a/Tasks/google-play-release/task.loc.json
+++ b/Tasks/google-play-release/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "130",
+    "Minor": "135",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/baseREADME.md
+++ b/baseREADME.md
@@ -1,6 +1,6 @@
 # Visual Studio Team Services Extension for Google Play
 
-This extension contains a set of deployment tasks which allow you to automate the release, promotion and rollout of app updates to the Google Play store from your CI environment. This can reduce the effort needed to keep your alpha, beta, rollout and production deployments up-to-date, since you can simply push changes to the configured source control branches, and let your automated build take care of the rest.
+This extension contains a set of deployment tasks which allow you to automate the release, promotion and rollout of app updates to the Google Play store from your CI environment. This can reduce the effort needed to keep your internal test, alpha, beta, rollout and production deployments up-to-date, since you can simply push changes to the configured source control branches, and let your automated build take care of the rest.
 
 ## Prerequisites
 

--- a/docs/vsts-README.md
+++ b/docs/vsts-README.md
@@ -1,6 +1,6 @@
 # Visual Studio Team Services Extension for Google Play
 
-This extension contains a set of deployment tasks which allow you to automate the release, promotion and rollout of app updates to the Google Play store from your CI environment. This can reduce the effort needed to keep your alpha, beta, rollout and production deployments up-to-date, since you can simply push changes to the configured source control branches, and let your automated build take care of the rest.
+This extension contains a set of deployment tasks which allow you to automate the release, promotion and rollout of app updates to the Google Play store from your CI environment. This can reduce the effort needed to keep your internal test, alpha, beta, rollout and production deployments up-to-date, since you can simply push changes to the configured source control branches, and let your automated build take care of the rest.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fix https://github.com/Microsoft/google-play-vsts-extension/issues/90 by adding support for new internal test track. Made the following changes:

Publish task: Added internal test as target and set internal as default
Promote task: Added internal test as source and default, added alpha as target

As internal test will probably be used for most automated deployments, I configured it as default. 
