### PR TITLE
Update README with missing step in service account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ In order to automate the release of app updates to the Google Play store, you ne
 
 6. Save the provided JSON file somewhere safe and memorable. You'll be using it later.
 
-7. Back in the **Google Play Developer Console**, click the **Done** button to close the modal
+7. Go to the **IAM** page and click on the **Add** button.
 
-8. Click the **Grant access** button in the row associated with the service account you just created.
+8. Select the newly created service account in the **New members** box and assign it the  **Service Account User Role**, then click **Save**.
+
+9. Back in the **Google Play Developer Console**, click the **Done** button to close the modal
+
+10. Click the **Grant access** button in the row associated with the service account you just created.
  
-9. Ensure that the **Role** is set to **Release Manager** and then click the **Add user** button
+11. Ensure that the **Role** is set to **Release Manager** and then click the **Add user** button
 
 To take advantage of the metadata updating capabilities, files need to be organized using fastlane’s [supply tool](https://github.com/fastlane/fastlane/tree/master/supply#readme) format:
 


### PR DESCRIPTION
I've been following the steps in the readme for setting up the Service Account, but a step was missing: assigning the `Service Account User` role to the account, after it was created. Without doing so, the account doesn't show up in the `Google Play Developer Console`, so I wasn't able to complete the last two steps.

Took me a while to figure out what was missing, so I'm updating this hoping it will help others in the same situation as I.