### PR TITLE
Bundle Task: fix input name and use node 10

### DIFF
--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "163",
+        "Minor": "164",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-promote/task.loc.json
+++ b/Tasks/google-play-promote/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "163",
+    "Minor": "164",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-release-bundle/GooglePlay.ps1
+++ b/Tasks/google-play-release-bundle/GooglePlay.ps1
@@ -1,7 +1,7 @@
 param (
     [string]$serviceAccountKey,
     [string]$serviceEndpoint,
-    [string]$packageName,
+    [string]$applicationId,
     [string]$bundleFile,
     [string]$track,
     [string]$userFraction,
@@ -10,7 +10,7 @@ param (
   
 $env:INPUT_serviceAccountKey = $serviceAccountKey
 $env:INPUT_serviceEndpoint = $serviceEndpoint
-$env:INPUT_packageName = $packageName
+$env:INPUT_applicationId = $applicationId
 $env:INPUT_bundleFile = $bundleFile
 $env:INPUT_track = $track
 $env:INPUT_userFraction = $userFraction

--- a/Tasks/google-play-release-bundle/GooglePlay.ts
+++ b/Tasks/google-play-release-bundle/GooglePlay.ts
@@ -30,7 +30,7 @@ async function run() {
             key.private_key = serviceEndpoint.parameters['password'].replace(/\\n/g, '\n');
         }
 
-        const packageName: string = tl.getInput('packageName', true);
+        const packageName: string = tl.getInput('applicationId', true);
         tl.debug(`Application identifier: ${packageName}`);
 
         const mainBundlePattern = tl.getPathInput('bundleFile', true);

--- a/Tasks/google-play-release-bundle/Tests/L0.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0.ts
@@ -50,7 +50,7 @@ describe('L0 Suite google-play-release-bundle', function () {
 
         testRunner.run();
 
-        assert(testRunner.createdErrorIssue('Error: Input required: packageName'), 'Did not print the expected message');
+        assert(testRunner.createdErrorIssue('Error: Input required: applicationId'), 'Did not print the expected message');
         assert(testRunner.failed, 'task should have failed');
         done();
     });

--- a/Tasks/google-play-release-bundle/Tests/L0AttachMetadata.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0AttachMetadata.ts
@@ -11,7 +11,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 tr.setInput('track', 'Production');
 tr.setInput('shouldAttachMetadata', 'true');

--- a/Tasks/google-play-release-bundle/Tests/L0BadVersionList.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0BadVersionList.ts
@@ -11,7 +11,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 tr.setInput('track', 'Production');
 tr.setInput('shouldAttachMetadata', 'true');

--- a/Tasks/google-play-release-bundle/Tests/L0DeobfuscationFileNotFound.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0DeobfuscationFileNotFound.ts
@@ -11,7 +11,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 tr.setInput('shouldUploadApks', 'true');
 tr.setInput('shouldUploadMappingFile', 'true');

--- a/Tasks/google-play-release-bundle/Tests/L0FoundDeobfuscationFile.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0FoundDeobfuscationFile.ts
@@ -11,7 +11,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 tr.setInput('shouldUploadApks', 'true');
 tr.setInput('shouldUploadMappingFile', 'true');

--- a/Tasks/google-play-release-bundle/Tests/L0HappyPath.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0HappyPath.ts
@@ -11,7 +11,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 tr.setInput('track', 'Alpha');
 tr.setInput('versionCodeFilterType', 'all');

--- a/Tasks/google-play-release-bundle/Tests/L0NoBundleFound.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0NoBundleFound.ts
@@ -9,7 +9,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 
 // provide answers for task mock

--- a/Tasks/google-play-release-bundle/Tests/L0NoBundleSupplied.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0NoBundleSupplied.ts
@@ -6,7 +6,7 @@ const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '');
 
 process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';

--- a/Tasks/google-play-release-bundle/Tests/L0NoPackageNameSupplied.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0NoPackageNameSupplied.ts
@@ -8,7 +8,7 @@ const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
 tr.setInput('bundleFile', '/path/to/bundle');
-tr.setInput('packageName', '');
+tr.setInput('applicationId', '');
 
 process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
 

--- a/Tasks/google-play-release-bundle/Tests/L0UpdateTrackWithVersionList.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0UpdateTrackWithVersionList.ts
@@ -11,7 +11,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 tr.setInput('track', 'Production');
 tr.setInput('shouldAttachMetadata', 'true');

--- a/Tasks/google-play-release-bundle/Tests/L0UseChangeLog.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0UseChangeLog.ts
@@ -11,7 +11,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 tr.setInput('track', 'Production');
 tr.setInput('shouldAttachMetadata', 'false');

--- a/Tasks/google-play-release-bundle/Tests/L0UseChangeLogFail.ts
+++ b/Tasks/google-play-release-bundle/Tests/L0UseChangeLogFail.ts
@@ -11,7 +11,7 @@ process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
-tr.setInput('packageName', 'myPackage');
+tr.setInput('applicationId', 'myPackage');
 tr.setInput('bundleFile', '/path/to/bundle');
 tr.setInput('track', 'Production');
 tr.setInput('shouldAttachMetadata', 'false');

--- a/Tasks/google-play-release-bundle/task.json
+++ b/Tasks/google-play-release-bundle/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "163",
+        "Minor": "164",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
@@ -193,7 +193,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node10": {
             "target": "GooglePlay.js",
             "argumentFormat": ""
         },

--- a/Tasks/google-play-release-bundle/task.loc.json
+++ b/Tasks/google-play-release-bundle/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "163",
+    "Minor": "164",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-release-bundle/task.loc.json
+++ b/Tasks/google-play-release-bundle/task.loc.json
@@ -193,7 +193,7 @@
     }
   ],
   "execution": {
-    "Node": {
+    "Node10": {
       "target": "GooglePlay.js",
       "argumentFormat": ""
     },

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "163",
+        "Minor": "164",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-release/task.loc.json
+++ b/Tasks/google-play-release/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "163",
+    "Minor": "164",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-rollout-update/task.json
+++ b/Tasks/google-play-rollout-update/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "163",
+        "Minor": "164",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-rollout-update/task.loc.json
+++ b/Tasks/google-play-rollout-update/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "163",
+    "Minor": "164",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "2.163.0",
+  "version": "2.164.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "2.163.0",
+  "version": "2.164.0",
   "description": "Provides build/release tasks that enable performing continuous delivery to the Google Play store from an automated VSTS build or release definition.",
   "repository": {
     "type": "git",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "3.163.0",
+    "version": "3.164.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
The newer bundle task took a dependency on a new version of the google api that internally uses asyc/await. But the default execution for tasks happens in node 6 which doesn't support async await. This was causing #142 

I've changed this task to execute using node 10 which supports async/await

Additionally, there was an input name mismatch where the task json declared the input applicationId but internally assumed it was named packageName. Looking through the code I suspect these were intended to be the same thing so I've changed the code to look up applicationId.

Bump version number everywhere to 164

- [x] still need to update tests