### PR TITLE
allow track to be editable. Extra logging on exception

### DIFF
--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "3",
         "Minor": "164",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "Promote $(packageName) from $(sourceTrack) to $(destinationTrack)",
@@ -72,6 +72,9 @@
                 "alpha": "Alpha",
                 "beta": "Beta",
                 "production": "Production"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {
@@ -85,6 +88,9 @@
                 "alpha": "Alpha",
                 "beta": "Beta",
                 "production": "Production"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {

--- a/Tasks/google-play-promote/task.loc.json
+++ b/Tasks/google-play-promote/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "3",
     "Minor": "164",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.83.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -72,6 +72,9 @@
         "alpha": "Alpha",
         "beta": "Beta",
         "production": "Production"
+      },
+      "properties": {
+          "EditableOptions": "True"
       }
     },
     {
@@ -85,6 +88,9 @@
         "alpha": "Alpha",
         "beta": "Beta",
         "production": "Production"
+      },
+      "properties": {
+          "EditableOptions": "True"
       }
     },
     {

--- a/Tasks/google-play-release-bundle/task.json
+++ b/Tasks/google-play-release-bundle/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "3",
         "Minor": "164",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [
@@ -86,6 +86,9 @@
                 "alpha": "Alpha",
                 "beta": "Beta",
                 "production": "Production"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {

--- a/Tasks/google-play-release-bundle/task.loc.json
+++ b/Tasks/google-play-release-bundle/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "3",
     "Minor": "164",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [
@@ -86,6 +86,9 @@
         "alpha": "Alpha",
         "beta": "Beta",
         "production": "Production"
+      },
+      "properties": {
+          "EditableOptions": "True"
       }
     },
     {

--- a/Tasks/google-play-release/GooglePlay.ts
+++ b/Tasks/google-play-release/GooglePlay.ts
@@ -168,6 +168,11 @@ async function run() {
         console.log(tl.loc('TrackInfo', track));
         tl.setResult(tl.TaskResult.Succeeded, tl.loc('Success'));
     } catch (e) {
+        if (e) {
+            tl.debug('Exception thrown releasing to Google Play: ' + e);
+        } else {
+            tl.debug('Unknown error, no response given from Google Play');
+        }
         tl.setResult(tl.TaskResult.Failed, e);
     }
 }

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "3",
         "Minor": "164",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [
@@ -79,6 +79,9 @@
                 "alpha": "Alpha",
                 "beta": "Beta",
                 "production": "Production"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {

--- a/Tasks/google-play-release/task.loc.json
+++ b/Tasks/google-play-release/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "3",
     "Minor": "164",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [
@@ -79,6 +79,9 @@
         "alpha": "Alpha",
         "beta": "Beta",
         "production": "Production"
+      },
+      "properties": {
+          "EditableOptions": "True"
       }
     },
     {

--- a/Tasks/google-play-rollout-update/task.json
+++ b/Tasks/google-play-rollout-update/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "2",
         "Minor": "164",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "Increase $(packageName) rollout fraction to $(userFraction)",
@@ -72,6 +72,9 @@
                 "alpha": "Alpha",
                 "beta": "Beta",
                 "production": "Production"
+            },
+            "properties": {
+                "EditableOptions": "True"
             }
         },
         {

--- a/Tasks/google-play-rollout-update/task.loc.json
+++ b/Tasks/google-play-rollout-update/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "2",
     "Minor": "164",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.83.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -72,6 +72,9 @@
         "alpha": "Alpha",
         "beta": "Beta",
         "production": "Production"
+      },
+      "properties": {
+          "EditableOptions": "True"
       }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "2.164.0",
+  "version": "2.164.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "2.164.0",
+  "version": "2.164.1",
   "description": "Provides build/release tasks that enable performing continuous delivery to the Google Play store from an automated VSTS build or release definition.",
   "repository": {
     "type": "git",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "3.164.0",
+    "version": "3.164.1",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
This sets the track input for all tasks to be editable. Meaning you can type in your own track if you don't want to use one of the predefined alpha, beta, etc tracks.