### PR TITLE
Added override for mainfest package

### DIFF
--- a/Tasks/google-play-release/GooglePlay.ts
+++ b/Tasks/google-play-release/GooglePlay.ts
@@ -92,7 +92,8 @@ async function run() {
         // #7) Commit the edit transaction
 
         tl.debug(`Getting a package name from ${mainApkFile}`);
-        const packageName: string = manifest.package;
+        const mainfestPackageName: string = tl.getInput('mainfestPackageName', true);
+        const packageName: string = mainfestPackageName ||  manifest.package;
         googleutil.updateGlobalParams(globalParams, 'packageName', packageName);
 
         tl.debug('Initializing JWT.');

--- a/Tasks/google-play-release/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/google-play-release/Strings/resources.resjson/en-US/resources.resjson
@@ -38,6 +38,8 @@
   "loc.input.help.additionalApks": "Paths to additional APK files you want to publish to the specified track (e.g. an x86 build). Wildcards can be used. For example, _\\*\\*/\\*.apk_ to match all APK files, in any directory.",
   "loc.input.label.shouldPickObbFileForAdditonalApks": "Upload Obbs",
   "loc.input.help.shouldPickObbFileForAdditonalApks": "Select this option to pick obb file for the apk. If present in the parent directory, it will pick the first file with .obb extension, else it will pick from apk directory with expected format as main.<version code>.<package name>.obb",
+  "loc.input.label.mainfestPackageName": "Manifest Package",
+  "loc.input.help.mainfestPackageName": "Overide the package name automatically used from the AndroidManifest.xml file.",
   "loc.input.label.versionCodeFilterType": "Replace version codes",
   "loc.input.help.versionCodeFilterType": "Specify version codes to replace in the selected track with the new APKs: all, the comma separated list, or a regular expression pattern.",
   "loc.input.label.replaceList": "Version code list",

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -230,8 +230,17 @@
             "required": true,
             "helpMarkDown": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
             "visibleRule": "versionCodeFilterType = expression"
+        },
+        {
+            "name": "mainfestPackageName",
+            "type": "string",
+            "label": "Manifest Package",
+            "defaultValue": "",
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Overide the package name automatically used from the AndroidManifest.xml file."
         }
-    ],
+	],
     "execution": {
         "Node": {
             "target": "GooglePlay.js",

--- a/Tasks/google-play-release/task.json
+++ b/Tasks/google-play-release/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "174",
+        "Minor": "178",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
@@ -238,7 +238,7 @@
             "defaultValue": "",
             "groupName": "advanced",
             "required": false,
-            "helpMarkDown": "Overide the package name automatically used from the AndroidManifest.xml file."
+            "helpMarkDown": "Override the package name automatically used from the AndroidManifest.xml file."
         }
 	],
     "execution": {

--- a/Tasks/google-play-release/task.loc.json
+++ b/Tasks/google-play-release/task.loc.json
@@ -230,7 +230,16 @@
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.replaceExpression",
       "visibleRule": "versionCodeFilterType = expression"
-    }
+    },
+    {
+      "name": "mainfestPackageName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.mainfestPackageName",
+      "defaultValue": "",
+      "groupName": "advanced",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.mainfestPackageName"
+    },
   ],
   "execution": {
     "Node": {


### PR DESCRIPTION
Added the ability to override the package value which is only pulled from the Android Manifest file.

In a deployment I use, we have the Azure pipelines set different package values automatically that represent different environments. 

This change facilitates the same application for different environments (which can be installed side-by-side) being automatically published to the same app registration in the Google Play Console. Currently we distribute to AppCenter then push to Google Play.