### PR TITLE
[google-play-promote] Ability to disable track cleanup

### DIFF
--- a/Tasks/google-play-promote/google-play-promote.ts
+++ b/Tasks/google-play-promote/google-play-promote.ts
@@ -33,6 +33,7 @@ async function run() {
         const destinationTrack: string = tl.getInput('destinationTrack', true);
         const userFractionSupplied: boolean = tl.getBoolInput('rolloutToUserFraction');
         const userFraction: number = Number(userFractionSupplied ? tl.getInput('userFraction', false) : 1.0);
+        const dontCleanSourceTrack: boolean = tl.getBoolInput('dontCleanTheSourceTrack');
 
         // Constants
         const globalParams: googleutil.GlobalParams = { auth: null, params: {} };
@@ -55,6 +56,12 @@ async function run() {
         console.log(tl.loc('PromoteTrack', destinationTrack));
         track = await googleutil.updateTrack(edits, packageName, destinationTrack, track.releases[0].versionCodes, userFraction, track.releases[0].releaseNotes);
         tl.debug(`Update track: ${JSON.stringify(track)}`);
+
+        if (!dontCleanSourceTrack) {
+            console.log(tl.loc('CleanTrack', sourceTrack));
+            track = await googleutil.updateTrack(edits, packageName, sourceTrack, [], userFraction);
+            tl.debug(`Update clean track: ${JSON.stringify(track)}`);
+        }
 
         await edits.commit();
 

--- a/Tasks/google-play-promote/google-play-promote.ts
+++ b/Tasks/google-play-promote/google-play-promote.ts
@@ -56,10 +56,6 @@ async function run() {
         track = await googleutil.updateTrack(edits, packageName, destinationTrack, track.releases[0].versionCodes, userFraction, track.releases[0].releaseNotes);
         tl.debug(`Update track: ${JSON.stringify(track)}`);
 
-        console.log(tl.loc('CleanTrack', sourceTrack));
-        track = await googleutil.updateTrack(edits, packageName, sourceTrack, [], userFraction);
-        tl.debug(`Update clean track: ${JSON.stringify(track)}`);
-
         await edits.commit();
 
         console.log(tl.loc('PromoteSucceed'));

--- a/Tasks/google-play-promote/google-play-promote.ts
+++ b/Tasks/google-play-promote/google-play-promote.ts
@@ -33,7 +33,7 @@ async function run() {
         const destinationTrack: string = tl.getInput('destinationTrack', true);
         const userFractionSupplied: boolean = tl.getBoolInput('rolloutToUserFraction');
         const userFraction: number = Number(userFractionSupplied ? tl.getInput('userFraction', false) : 1.0);
-        const dontCleanSourceTrack: boolean = tl.getBoolInput('dontCleanTheSourceTrack');
+        const сleanSourceTrack: boolean = tl.getBoolInput('сleanTheSourceTrack');
 
         // Constants
         const globalParams: googleutil.GlobalParams = { auth: null, params: {} };
@@ -57,7 +57,7 @@ async function run() {
         track = await googleutil.updateTrack(edits, packageName, destinationTrack, track.releases[0].versionCodes, userFraction, track.releases[0].releaseNotes);
         tl.debug(`Update track: ${JSON.stringify(track)}`);
 
-        if (!dontCleanSourceTrack) {
+        if (сleanSourceTrack) {
             console.log(tl.loc('CleanTrack', sourceTrack));
             track = await googleutil.updateTrack(edits, packageName, sourceTrack, [], userFraction);
             tl.debug(`Update clean track: ${JSON.stringify(track)}`);

--- a/Tasks/google-play-promote/googleutil.ts
+++ b/Tasks/google-play-promote/googleutil.ts
@@ -180,6 +180,9 @@ export async function updateTrack(edits: any, packageName: string, track: string
 
     tl.debug('Additional Parameters: ' + JSON.stringify(requestParameters));
     const updatedTrack = await edits.tracks.update(requestParameters);
+    if (!updatedTrack) {
+        throw new Error(tl.loc('ReturnedNullEdit'));
+    }
     tl.debug(`Update track response: ${updatedTrack.status} ${updatedTrack.statusText}`);
     return updatedTrack.data;
 }

--- a/Tasks/google-play-promote/googleutil.ts
+++ b/Tasks/google-play-promote/googleutil.ts
@@ -180,6 +180,9 @@ export async function updateTrack(edits: any, packageName: string, track: string
 
     tl.debug('Additional Parameters: ' + JSON.stringify(requestParameters));
     const updatedTrack = await edits.tracks.update(requestParameters);
+    if (updatedTrack.status !== 200) {
+        tl.debug(`Update track response: ${updatedTrack.status} ${updatedTrack.statusText}`);
+    }
     return updatedTrack.data;
 }
 

--- a/Tasks/google-play-promote/googleutil.ts
+++ b/Tasks/google-play-promote/googleutil.ts
@@ -180,9 +180,7 @@ export async function updateTrack(edits: any, packageName: string, track: string
 
     tl.debug('Additional Parameters: ' + JSON.stringify(requestParameters));
     const updatedTrack = await edits.tracks.update(requestParameters);
-    if (updatedTrack.status !== 200) {
-        tl.debug(`Update track response: ${updatedTrack.status} ${updatedTrack.statusText}`);
-    }
+    tl.debug(`Update track response: ${updatedTrack.status} ${updatedTrack.statusText}`);
     return updatedTrack.data;
 }
 

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -14,8 +14,8 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "170",
-        "Patch": "1"
+        "Minor": "172",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "Promote $(packageName) from $(sourceTrack) to $(destinationTrack)",
@@ -143,6 +143,7 @@
         "SourceTrack": "Source track: %s",
         "DestTrack": "Destination track: %s",
         "Success": "Successfully promote APK.",
-        "Failure": "Failed to promote APK."
+        "Failure": "Failed to promote APK.",
+        "ReturnedNullEdit": "Returned null edit"
     }
 }

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -111,12 +111,12 @@
             "visibleRule": "rolloutToUserFraction = true"
         },
         {
-            "name": "dontCleanTheSourceTrack",
+            "name": "сleanTheSourceTrack",
             "type": "boolean",
-            "label": "Don't clean the source track",
-            "defaultValue": false,
+            "label": "Сlean the source track",
+            "defaultValue": true,
             "required": false,
-            "helpMarkDown": "Source track will not be cleared"
+            "helpMarkDown": "Source track will be cleared"
         }
     ],
     "execution": {

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -109,6 +109,14 @@
             "required": false,
             "helpMarkDown": "The percentage of users the specified APK will be released to for the specified 'Destination track'. It can be increased later with the 'Google Play - Increase Rollout' task.",
             "visibleRule": "rolloutToUserFraction = true"
+        },
+        {
+            "name": "dontCleanTheSourceTrack",
+            "type": "boolean",
+            "label": "Don't clean the source track",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "Source track will not be cleared"
         }
     ],
     "execution": {

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "172",
+        "Minor": "173",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -144,6 +144,6 @@
         "DestTrack": "Destination track: %s",
         "Success": "Successfully promote APK.",
         "Failure": "Failed to promote APK.",
-        "ReturnedNullEdit": "Returned null edit"
+        "ReturnedNullEdit": "Failed to promote apk: promote operation returned null"
     }
 }

--- a/Tasks/google-play-promote/task.loc.json
+++ b/Tasks/google-play-promote/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "170",
+    "Minor": "172",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",
@@ -109,6 +109,14 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.userFraction",
       "visibleRule": "rolloutToUserFraction = true"
+    },
+    {
+      "name": "сleanTheSourceTrack",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.сleanTheSourceTrack",
+      "defaultValue": true,
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.сleanTheSourceTrack"
     }
   ],
   "execution": {
@@ -135,7 +143,8 @@
     "SourceTrack": "ms-resource:loc.messages.SourceTrack",
     "DestTrack": "ms-resource:loc.messages.DestTrack",
     "Success": "ms-resource:loc.messages.Success",
-    "Failure": "ms-resource:loc.messages.Failure"
+    "Failure": "ms-resource:loc.messages.Failure",
+    "ReturnedNullEdit": "ms-resource:loc.messages.ReturnedNullEdit"
   },
   "helpMarkDown": "ms-resource:loc.helpMarkDown"
 }

--- a/Tasks/google-play-promote/task.loc.json
+++ b/Tasks/google-play-promote/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "172",
+    "Minor": "173",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",


### PR DESCRIPTION
**Task name**: google-play-promote

**Description**: This PR adds the ability to disable source track cleanup. An additional checkbox "Clean the source track" has been added, the checkbox is checked by default. If you want to keep the source track after the "promote" operation, please uncheck this box. Also in this PR added logging for the status of the track after the "Promote" operation.

**Documentation changes required:** (Y) 

**Added unit tests:** (N) 

**Attached related issue:** (Y) https://github.com/microsoft/google-play-vsts-extension/issues/166

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

![cleanTheSourceTrack](https://user-images.githubusercontent.com/17137147/85529327-99418d80-b615-11ea-9582-71528b2e70e3.PNG)
