### PR TITLE
[GooglePlayExtension] Bump extension version to 174

### DIFF
--- a/Tasks/google-play-promote/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/google-play-promote/Strings/resources.resjson/en-US/resources.resjson
@@ -17,6 +17,8 @@
   "loc.input.help.rolloutToUserFraction": "Promote the release to a percentage of users. Use the 'Google Play - Increase Rollout' task to increase the rollout within a track.",
   "loc.input.label.userFraction": "Rollout fraction",
   "loc.input.help.userFraction": "The percentage of users the specified APK will be released to for the specified 'Destination track'. It can be increased later with the 'Google Play - Increase Rollout' task.",
+  "loc.input.label.сleanTheSourceTrack": "Сlean the source track",
+  "loc.input.help.сleanTheSourceTrack": "Source track will be cleared",
   "loc.messages.InvalidAuthFile": "Specified auth file was invalid",
   "loc.messages.InvalidAuthFilewithName": "%s was not a valid auth file",
   "loc.messages.JsonKeyFileNotFound": "The service account JSON key file could not be found.",
@@ -29,5 +31,6 @@
   "loc.messages.SourceTrack": "Source track: %s",
   "loc.messages.DestTrack": "Destination track: %s",
   "loc.messages.Success": "Successfully promote APK.",
-  "loc.messages.Failure": "Failed to promote APK."
+  "loc.messages.Failure": "Failed to promote APK.",
+  "loc.messages.ReturnedNullEdit": "Failed to promote apk: promote operation returned null"
 }

--- a/Tasks/google-play-promote/task.json
+++ b/Tasks/google-play-promote/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "172",
+        "Minor": "174",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-promote/task.loc.json
+++ b/Tasks/google-play-promote/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "172",
+    "Minor": "174",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-release-bundle/task.json
+++ b/Tasks/google-play-release-bundle/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "172",
+        "Minor": "174",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-release-bundle/task.loc.json
+++ b/Tasks/google-play-release-bundle/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "172",
+    "Minor": "174",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-rollout-update/task.json
+++ b/Tasks/google-play-rollout-update/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "172",
+        "Minor": "174",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",

--- a/Tasks/google-play-rollout-update/task.loc.json
+++ b/Tasks/google-play-rollout-update/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "172",
+    "Minor": "174",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "2.172.0",
+  "version": "2.174.0",
   "description": "Provides build/release tasks that enable performing continuous delivery to the Google Play store from an automated VSTS build or release definition.",
   "repository": {
     "type": "git",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "3.172.0",
+    "version": "3.174.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
**Task name**: 
- GooglePlayPromote
- GooglePlayReleaseBundle
- GooglePlayIncreaseRollout

**Description**: 
Bumped tasks version to 174 to prepare for the new release

*Changes:*
- Bumped tasks  version to 174 
- Bumped extension version to 174

**Documentation changes required:** N

**Added unit tests:** N 

**Attached related issue:** 
- https://github.com/microsoft/build-task-team/issues/194

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
- [x] All unit-tests passed 
![image](https://user-images.githubusercontent.com/14060121/90505639-a08ba000-e15b-11ea-81d7-ed7bb481b528.png)

**Note**:
- I added `resources.resjson` changes  for `Google Promote Task`  since were lost in related [PR](https://github.com/microsoft/google-play-vsts-extension/pull/190)