### PR TITLE
[build script] Remove tsc and tsserver symbolic links

### DIFF
--- a/make-util.js
+++ b/make-util.js
@@ -165,7 +165,14 @@ var buildNodeTask = function (taskPath, outDir) {
     if (overrideTscPath) {
         var tscExec = path.join(overrideTscPath, "bin", "tsc");
         run("node " + tscExec + ' --outDir "' + outDir + '" --rootDir "' + taskPath + '"');
-        // Don't include typescript in node_modules
+
+        // Don't include typescript in node_modules:
+        // remove tsc and tsserver symbolic links
+        if (os.platform !== 'win32') {
+            rm('-f', path.join(taskPath, 'node_modules', '.bin', 'tsc'));
+            rm('-f', path.join(taskPath, 'node_modules', '.bin', 'tsserver'));
+        }
+        // remove typescript from node_modules
         rm("-rf", overrideTscPath);
     } else {
         run('tsc --outDir "' + outDir + '" --rootDir "' + taskPath + '"');


### PR DESCRIPTION
The fix was [introduced here.](https://github.com/microsoft/app-store-vsts-extension/pull/209)

[GooglePlayExtension CI pipeline](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=14261737&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=b6d2c347-7b49-5fd1-6216-64895449178b) is failing on `gulp create` while migrating tasks to node10 (on macOS and Ubuntu)
```
Creating PRODUCTION vsix...

[13:49:05] '<anonymous>' errored after 3.28 s
[13:49:05] Error: exited with error code: 255
    at ChildProcess.onexit (/Users/runner/work/1/s/node_modules/end-of-stream/index.js:40:36)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:198:12)
[13:49:05] 'packageprod' errored after 4.61 s
```

It looks like the issue came from vsix-writer:
```
Error: ENOENT: no such file or directory, open '/home/max/mz-app-store-vsts-extension/_build/Tasks/AppStorePromote/node_modules/.bin/tsc'
Error: ENOENT: no such file or directory, open '/home/max/mz-app-store-vsts-extension/_build/Tasks/AppStorePromote/node_modules/.bin/tsserver'
```
`tsc` and `tsserver` symbolic links are broken after removing the typescript.