### PR TITLE
Support halting rollout

### DIFF
--- a/Tasks/GooglePlayRolloutUpdate/googleutil.ts
+++ b/Tasks/GooglePlayRolloutUpdate/googleutil.ts
@@ -165,6 +165,12 @@ export async function updateTrack(edits: any, packageName: string, track: string
         release.userFraction = userFraction;
         release.status = 'inProgress';
     } else if (userFraction <= 0) {
+        // If userFraction is less than 0, consider it as a halting signal
+        // set this to 0.1 to avoid following errors:
+        // - Error: HALTED release must have fraction
+        // - Error: Rollout fraction must be greater than 0 and less than 1
+        // As the rollout is halted, so no actual impact of fraction will be introduced.
+        release.userFraction = 0.1;
         release.status = 'halted';
     } else {
         tl.debug('User fraction is more than 100% marking rollout "completed"');

--- a/Tasks/GooglePlayRolloutUpdate/googleutil.ts
+++ b/Tasks/GooglePlayRolloutUpdate/googleutil.ts
@@ -161,7 +161,7 @@ export async function updateTrack(edits: any, packageName: string, track: string
         release.releaseNotes = releaseNotes;
     }
 
-    if (userFraction < 1.0) {
+    if (userFraction < 1.0 && userFraction > 0) {
         release.userFraction = userFraction;
         release.status = 'inProgress';
     } else if (userFraction <= 0) {

--- a/Tasks/GooglePlayRolloutUpdate/googleutil.ts
+++ b/Tasks/GooglePlayRolloutUpdate/googleutil.ts
@@ -164,6 +164,8 @@ export async function updateTrack(edits: any, packageName: string, track: string
     if (userFraction < 1.0) {
         release.userFraction = userFraction;
         release.status = 'inProgress';
+    } else if (userFraction <= 0) {
+        release.status = 'halted';
     } else {
         tl.debug('User fraction is more than 100% marking rollout "completed"');
         release.status = 'completed';


### PR DESCRIPTION
**Task name**:  GooglePlayRolloutUpdate

**Description**: support halting rollout when fraction set to 0 or less

**Documentation changes required:** (Y/N) Y

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/google-play-vsts-extension/issues/240

**Checklist**:
- [ ] Task version was bumped - Not yet, but I will do this later: please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected, not yet
