### PR TITLE
[GooglePlayPromote] Fix task not failing when versionCode is not valid

### DIFF
--- a/Tasks/GooglePlayPromote/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayPromote/Strings/resources.resjson/en-US/resources.resjson
@@ -27,6 +27,7 @@
   "loc.messages.EndpointNotFound": "The service connection could not be found.",
   "loc.messages.Authenticating": "Authenticating with Google Play",
   "loc.messages.GetTrackInfo": "Getting information for track %s",
+  "loc.messages.InvalidVersionCode": "Version code should be a positive integer",
   "loc.messages.PromoteTrack": "Promoting to track %s",
   "loc.messages.CleanTrack": "Cleaning up track %s",
   "loc.messages.PromoteSucceed": "APK successfully promoted!",

--- a/Tasks/GooglePlayPromote/google-play-promote.ts
+++ b/Tasks/GooglePlayPromote/google-play-promote.ts
@@ -58,7 +58,13 @@ async function run() {
         let releaseNotes = track.releases[0].releaseNotes;
 
         if (versionCode !== undefined) {
-            versionNumber = [Number(versionCode)];
+            const versionCodeNumber = Number(versionCode);
+
+            if (!Number.isInteger(versionCodeNumber) || versionCodeNumber <= 0) {
+                tl.setResult(tl.TaskResult.Failed, tl.loc('InvalidVersionCode'));
+            }
+
+            versionNumber = [versionCodeNumber];
             // don't override the release notes with latest release notes, potentially dangerous
             releaseNotes = undefined;
         }

--- a/Tasks/GooglePlayPromote/google-play-promote.ts
+++ b/Tasks/GooglePlayPromote/google-play-promote.ts
@@ -61,7 +61,7 @@ async function run() {
             const versionCodeNumber = Number(versionCode);
 
             if (!Number.isInteger(versionCodeNumber) || versionCodeNumber <= 0) {
-                tl.setResult(tl.TaskResult.Failed, tl.loc('InvalidVersionCode'));
+                throw new Error(tl.loc('InvalidVersionCode'));
             }
 
             versionNumber = [versionCodeNumber];

--- a/Tasks/GooglePlayPromote/task.json
+++ b/Tasks/GooglePlayPromote/task.json
@@ -145,6 +145,7 @@
         "EndpointNotFound": "The service connection could not be found.",
         "Authenticating": "Authenticating with Google Play",
         "GetTrackInfo": "Getting information for track %s",
+        "InvalidVersionCode": "Version code should be a positive integer",
         "PromoteTrack": "Promoting to track %s",
         "CleanTrack": "Cleaning up track %s",
         "PromoteSucceed": "APK successfully promoted!",

--- a/Tasks/GooglePlayPromote/task.json
+++ b/Tasks/GooglePlayPromote/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "3",
         "Minor": "186",
-        "Patch": "1"
+        "Patch": "2"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Promote $(packageName) from $(sourceTrack) to $(destinationTrack)",

--- a/Tasks/GooglePlayPromote/task.loc.json
+++ b/Tasks/GooglePlayPromote/task.loc.json
@@ -145,6 +145,7 @@
     "EndpointNotFound": "ms-resource:loc.messages.EndpointNotFound",
     "Authenticating": "ms-resource:loc.messages.Authenticating",
     "GetTrackInfo": "ms-resource:loc.messages.GetTrackInfo",
+    "InvalidVersionCode": "ms-resource:loc.messages.InvalidVersionCode",
     "PromoteTrack": "ms-resource:loc.messages.PromoteTrack",
     "CleanTrack": "ms-resource:loc.messages.CleanTrack",
     "PromoteSucceed": "ms-resource:loc.messages.PromoteSucceed",

--- a/Tasks/GooglePlayPromote/task.loc.json
+++ b/Tasks/GooglePlayPromote/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "3",
     "Minor": "186",
-    "Patch": "1"
+    "Patch": "2"
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**: GooglePlayPromote

**Documentation changes required:** No

**Added unit tests:** No

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected