### PR TITLE
Remove all .d.ts files on .vsix creation to decrease extension bundle size

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ function toOverrideString(object) {
 }
 
 gulp.task('cleanpackagefiles', gulp.series(function (done) {
-    return del(['_build/Tasks/**/Tests', '_build/Tasks/**/*.js.map'], done);
+    return del(['_build/Tasks/**/Tests', '_build/Tasks/**/*.js.map', '_build/Tasks/**/*.d.ts'], done);
 }));
 
 gulp.task('create', gulp.series('installtaskdeps', 'cleanpackagefiles', function (cb) {


### PR DESCRIPTION
**Description**: We've noticed that .d.ts files compose the majority of node_modules' folder size. Removing these files decreases extension size from ~36mb to ~12 mb.

**Documentation changes required:** No

**Added unit tests:** No

**Checklist**:
- [x] Checked that applied changes work as expected
