### PR TITLE
#133 #256 Allow release status to be set as 'draft' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Allows you to release an app bundle to Google Play, and includes the following o
 
 9. **Deobfuscation Path** *(String, Optional)* - The path to the proguard mapping.txt file to upload.
 
-10. **Rollout Fraction** *(String, Optional)* - The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task.
+10. **Rollout Fraction** *(String, Optional)* - The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task. To publish as a draft set value to -1.
 
 11. **Metadata Root Directory** *(String, Required)* - Root directory for metadata related files. Becomes available after enabling the `Update Metadata` option. Expects a format similar to fastlane’s [supply tool](https://github.com/fastlane/fastlane/tree/master/supply#readme) which is summarized below:
  

--- a/Tasks/GooglePlayPromote/googleutil.ts
+++ b/Tasks/GooglePlayPromote/googleutil.ts
@@ -161,7 +161,10 @@ export async function updateTrack(edits: any, packageName: string, track: string
         release.releaseNotes = releaseNotes;
     }
 
-    if (userFraction < 1.0) {
+    if (userFraction === -1) {
+        tl.debug('User fraction is -1, marking rollout "draft"');
+        release.status = 'draft';
+    } else if (userFraction < 1.0) {
         release.userFraction = userFraction;
         release.status = 'inProgress';
     } else {

--- a/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.rolloutToUserFraction": "Roll out release",
   "loc.input.help.rolloutToUserFraction": "Roll out the release to a percentage of users.",
   "loc.input.label.userFraction": "Rollout fraction",
-  "loc.input.help.userFraction": "The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task.",
+  "loc.input.help.userFraction": "The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task. To publish as a draft set value to -1.",
   "loc.input.label.shouldAttachMetadata": "Update metadata",
   "loc.input.help.shouldAttachMetadata": "Select this option to update the metadata on your app release.",
   "loc.input.label.changeLogFile": "Release notes (file)",

--- a/Tasks/GooglePlayRelease/googleutil.ts
+++ b/Tasks/GooglePlayRelease/googleutil.ts
@@ -176,7 +176,10 @@ export async function updateTrack(edits: any, packageName: string, track: string
         release.releaseNotes = releaseNotes;
     }
 
-    if (userFraction < 1.0) {
+    if (userFraction === -1) {
+        tl.debug('User fraction is -1, marking rollout "draft"');
+        release.status = 'draft';
+    } else if (userFraction < 1.0) {
         release.userFraction = userFraction;
         release.status = 'inProgress';
     } else {

--- a/Tasks/GooglePlayRelease/task.json
+++ b/Tasks/GooglePlayRelease/task.json
@@ -106,7 +106,7 @@
             "label": "Rollout fraction",
             "defaultValue": "1.0",
             "required": false,
-            "helpMarkDown": "The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task.",
+            "helpMarkDown": "The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task. To publish as a draft set value to -1.",
             "visibleRule": "rolloutToUserFraction = true"
         },
         {

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.rolloutToUserFraction": "Roll out release",
   "loc.input.help.rolloutToUserFraction": "Roll out the release to a percentage of users.",
   "loc.input.label.userFraction": "Rollout fraction",
-  "loc.input.help.userFraction": "The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task.",
+  "loc.input.help.userFraction": "The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task. To publish as a draft set value to -1.",
   "loc.input.label.shouldAttachMetadata": "Update metadata",
   "loc.input.help.shouldAttachMetadata": "Select this option to update the metadata on your app release.",
   "loc.input.label.changeLogFile": "Release notes (file)",

--- a/Tasks/GooglePlayReleaseBundle/googleutil.ts
+++ b/Tasks/GooglePlayReleaseBundle/googleutil.ts
@@ -131,7 +131,10 @@ export async function updateTrack(edits: pub3.Resource$Edits, packageName: strin
         release.releaseNotes = releaseNotes;
     }
 
-    if (userFraction < 1.0) {
+    if (userFraction === -1) {
+        tl.debug('User fraction is -1, marking rollout "draft"');
+        release.status = 'draft';
+    } else if (userFraction < 1.0) {
         release.userFraction = userFraction;
         release.status = 'inProgress';
     } else {

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -105,7 +105,7 @@
             "label": "Rollout fraction",
             "defaultValue": "1.0",
             "required": false,
-            "helpMarkDown": "The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task.",
+            "helpMarkDown": "The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task. To publish as a draft set value to -1.",
             "visibleRule": "rolloutToUserFraction = true"
         },
         {

--- a/Tasks/GooglePlayRolloutUpdate/googleutil.ts
+++ b/Tasks/GooglePlayRolloutUpdate/googleutil.ts
@@ -161,7 +161,10 @@ export async function updateTrack(edits: any, packageName: string, track: string
         release.releaseNotes = releaseNotes;
     }
 
-    if (userFraction < 1.0) {
+    if (userFraction === -1) {
+        tl.debug('User fraction is -1, marking rollout "draft"');
+        release.status = 'draft';
+    } else if (userFraction < 1.0) {
         release.userFraction = userFraction;
         release.status = 'inProgress';
     } else {

--- a/baseREADME.md
+++ b/baseREADME.md
@@ -226,7 +226,7 @@ Allows you to release an app bundle to Google Play, and includes the following o
 
 9. **Deobfuscation Path** *(String, Optional)* - The path to the proguard mapping.txt file to upload.
 
-10. **Rollout Fraction** *(String, Optional)* - The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task.
+10. **Rollout Fraction** *(String, Optional)* - The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task. To publish as a draft set value to -1.
 
 11. **Metadata Root Directory** *(String, Required)* - Root directory for metadata related files. Becomes available after enabling the `Update Metadata` option. Expects a format similar to fastlane’s [supply tool](https://github.com/fastlane/fastlane/tree/master/supply#readme) which is summarized below:
  

--- a/docs/vsts-README.md
+++ b/docs/vsts-README.md
@@ -226,7 +226,7 @@ Allows you to release an app bundle to Google Play, and includes the following o
 
 9. **Deobfuscation Path** *(String, Optional)* - The path to the proguard mapping.txt file to upload.
 
-10. **Rollout Fraction** *(String, Optional)* - The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task.
+10. **Rollout Fraction** *(String, Optional)* - The percentage of users the specified APK will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task. To publish as a draft set value to -1.
 
 11. **Metadata Root Directory** *(String, Required)* - Root directory for metadata related files. Becomes available after enabling the `Update Metadata` option. Expects a format similar to fastlane’s [supply tool](https://github.com/fastlane/fastlane/tree/master/supply#readme) which is summarized below:
  


### PR DESCRIPTION
**Task name**: All

**Description**: Allow release status to be set as 'draft' (set rollout fraction to -1 to flag as draft release).

**Documentation changes required:** (Y/N) Y (included)

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) #133 / #256 

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
