### PR TITLE
[GooglePlayReleaseBundle]Add changesNotSentForReview option

### DIFF
--- a/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
+++ b/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
@@ -12,6 +12,7 @@ async function run() {
 
         tl.debug('Prepare task inputs.');
 
+        const sendChangesToReview: boolean = tl.getBoolInput('changesNotSentForReview');
         const authType: string = tl.getInput('authType', true);
         let key: googleutil.ClientKey = {};
         if (authType === 'JsonFile') {
@@ -135,7 +136,8 @@ async function run() {
         tl.debug('Updated track info: ' + JSON.stringify(updatedTrack));
 
         tl.debug('Committing the edit transaction in Google Play.');
-        await edits.commit();
+        //@ts-ignore
+        await edits.commit({ changesNotSentForReview: sendChangesToReview });
 
         console.log(tl.loc('AptPublishSucceed'));
         console.log(tl.loc('TrackInfo', track));

--- a/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
+++ b/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
@@ -136,6 +136,10 @@ async function run() {
         tl.debug('Updated track info: ' + JSON.stringify(updatedTrack));
 
         tl.debug('Committing the edit transaction in Google Play.');
+        // Need to use "@ts-ignore" because there is no changesNotSentForReview option 
+        // in this version of googleapis package but it still works as expected.
+        // It should be available in the next release 
+        // and we will update package version and remove this comment
         //@ts-ignore
         await edits.commit({ changesNotSentForReview: sendChangesToReview });
 
@@ -188,7 +192,7 @@ async function updateTrack(
         const oldTrackVersionCodes: string[] = res.releases[0].versionCodes.map((v) => `${v}`);
         tl.debug('Current version codes: ' + JSON.stringify(oldTrackVersionCodes));
 
-        if (typeof(versionCodeFilter) === 'string') {
+        if (typeof (versionCodeFilter) === 'string') {
             tl.debug(`Removing version codes matching the regular expression: ^${versionCodeFilter as string}$`);
             const versionCodesToRemove: RegExp = new RegExp(`^${versionCodeFilter as string}$`);
 
@@ -405,14 +409,14 @@ async function uploadMetadataWithLanguageCode(edits: pub3.Resource$Edits, apkVer
 async function addLanguageListing(edits: pub3.Resource$Edits, languageCode: string, directory: string) {
     const listingResource: googleutil.AndroidListingResource = createListingResource(languageCode, directory);
 
-    const isPatch:boolean = (!listingResource.fullDescription) ||
-                          (!listingResource.shortDescription) ||
-                          (!listingResource.title);
+    const isPatch: boolean = (!listingResource.fullDescription) ||
+        (!listingResource.shortDescription) ||
+        (!listingResource.title);
 
-    const isEmpty:boolean = (!listingResource.fullDescription) &&
-                          (!listingResource.shortDescription) &&
-                          (!listingResource.video) &&
-                          (!listingResource.title);
+    const isEmpty: boolean = (!listingResource.fullDescription) &&
+        (!listingResource.shortDescription) &&
+        (!listingResource.video) &&
+        (!listingResource.title);
 
     const listingRequestParameters: googleutil.PackageListingParams = {
         language: languageCode,
@@ -565,7 +569,7 @@ function getImageList(directory: string): { [key: string]: string[] } {
     const acceptedExtensions: string[] = ['.png', '.jpg', '.jpeg'];
 
     const imageDirectory: string = path.join(directory, 'images');
-    const imageList: { [key: string]: string[] }  = {};
+    const imageList: { [key: string]: string[] } = {};
 
     for (const imageType of imageTypes) {
         let shouldAttemptUpload: boolean = false;

--- a/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
+++ b/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
@@ -192,7 +192,7 @@ async function updateTrack(
         const oldTrackVersionCodes: string[] = res.releases[0].versionCodes.map((v) => `${v}`);
         tl.debug('Current version codes: ' + JSON.stringify(oldTrackVersionCodes));
 
-        if (typeof (versionCodeFilter) === 'string') {
+        if (typeof(versionCodeFilter) === 'string') {
             tl.debug(`Removing version codes matching the regular expression: ^${versionCodeFilter as string}$`);
             const versionCodesToRemove: RegExp = new RegExp(`^${versionCodeFilter as string}$`);
 
@@ -409,14 +409,14 @@ async function uploadMetadataWithLanguageCode(edits: pub3.Resource$Edits, apkVer
 async function addLanguageListing(edits: pub3.Resource$Edits, languageCode: string, directory: string) {
     const listingResource: googleutil.AndroidListingResource = createListingResource(languageCode, directory);
 
-    const isPatch: boolean = (!listingResource.fullDescription) ||
-        (!listingResource.shortDescription) ||
-        (!listingResource.title);
+    const isPatch:boolean = (!listingResource.fullDescription) ||
+                          (!listingResource.shortDescription) ||
+                          (!listingResource.title);
 
-    const isEmpty: boolean = (!listingResource.fullDescription) &&
-        (!listingResource.shortDescription) &&
-        (!listingResource.video) &&
-        (!listingResource.title);
+    const isEmpty:boolean = (!listingResource.fullDescription) &&
+                          (!listingResource.shortDescription) &&
+                          (!listingResource.video) &&
+                          (!listingResource.title);
 
     const listingRequestParameters: googleutil.PackageListingParams = {
         language: languageCode,
@@ -569,7 +569,7 @@ function getImageList(directory: string): { [key: string]: string[] } {
     const acceptedExtensions: string[] = ['.png', '.jpg', '.jpeg'];
 
     const imageDirectory: string = path.join(directory, 'images');
-    const imageList: { [key: string]: string[] } = {};
+    const imageList: { [key: string]: string[] }  = {};
 
     for (const imageType of imageTypes) {
         let shouldAttemptUpload: boolean = false;

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -40,6 +40,8 @@
   "loc.input.help.replaceList": "The comma separated list of APK version codes to be removed from the track with this deployment.",
   "loc.input.label.replaceExpression": "Version code pattern",
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
+  "loc.input.label.changesNotSentForReview": "Sent changes to review",
+  "loc.input.help.changesNotSentForReview": "Select this option to sent changes for review in GooglePlay Console. If changes're already send for review automatically, you mustn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters).",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
   "loc.messages.FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -41,7 +41,7 @@
   "loc.input.label.replaceExpression": "Version code pattern",
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
   "loc.input.label.changesNotSentForReview": "Sent changes to review",
-  "loc.input.help.changesNotSentForReview": "Select this option to sent changes for review in GooglePlay Console. If changes're already send for review automatically, you mustn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters).",
+  "loc.input.help.changesNotSentForReview": "Select this option to send changes for review in GooglePlay Console. If changes're already sent for review automatically, you shouldn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters).",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
   "loc.messages.FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -40,7 +40,7 @@
   "loc.input.help.replaceList": "The comma separated list of APK version codes to be removed from the track with this deployment.",
   "loc.input.label.replaceExpression": "Version code pattern",
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
-  "loc.input.label.changesNotSentForReview": "Sent changes to review",
+  "loc.input.label.changesNotSentForReview": "Send changes to review",
   "loc.input.help.changesNotSentForReview": "Select this option to send changes for review in GooglePlay Console. If changes're already sent for review automatically, you shouldn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters).",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainBundle": "Found main bundle to upload: %s (version code %s)",

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -226,7 +226,7 @@
             "groupName": "advanced",
             "defaultValue": false,
             "required": false,
-            "helpMarkDown": "Select this option to sent changes for review in GooglePlay Console. If changes already send for review automatically, you mustn't selecet this. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters)."
+            "helpMarkDown": "Select this option to sent changes for review in GooglePlay Console. If changes're already send for review automatically, you mustn't selecet this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters)."
         }
     ],
     "execution": {

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -14,8 +14,8 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "187",
-        "Patch": "1"
+        "Minor": "188",
+        "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
     "groups": [

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "3",
         "Minor": "187",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "2.182.1",
     "groups": [

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -226,7 +226,7 @@
             "groupName": "advanced",
             "defaultValue": false,
             "required": false,
-            "helpMarkDown": "Select this option to sent changes for review in GooglePlay Console. If changes're already send for review automatically, you mustn't selecet this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters)."
+            "helpMarkDown": "Select this option to sent changes for review in GooglePlay Console. If changes're already send for review automatically, you mustn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters)."
         }
     ],
     "execution": {

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -226,7 +226,7 @@
             "groupName": "advanced",
             "defaultValue": false,
             "required": false,
-            "helpMarkDown": "Select this option to sent changes for review in GooglePlay Console. If changes're already send for review automatically, you mustn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters)."
+            "helpMarkDown": "Select this option to send changes for review in GooglePlay Console. If changes're already sent for review automatically, you shouldn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters)."
         }
     ],
     "execution": {

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -222,7 +222,7 @@
         {
             "name": "changesNotSentForReview",
             "type": "boolean",
-            "label": "Sent changes to review",
+            "label": "Send changes to review",
             "groupName": "advanced",
             "defaultValue": false,
             "required": false,

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -218,6 +218,15 @@
             "required": true,
             "helpMarkDown": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
             "visibleRule": "versionCodeFilterType = expression"
+        },
+        {
+            "name": "changesNotSentForReview",
+            "type": "boolean",
+            "label": "Sent changes to review",
+            "groupName": "advanced",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "Select this option to sent changes for review in GooglePlay Console. If changes already send for review automatically, you mustn't selecet this. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters)."
         }
     ],
     "execution": {

--- a/Tasks/GooglePlayReleaseBundle/task.loc.json
+++ b/Tasks/GooglePlayReleaseBundle/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "3",
     "Minor": "187",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.182.1",
   "groups": [

--- a/Tasks/GooglePlayReleaseBundle/task.loc.json
+++ b/Tasks/GooglePlayReleaseBundle/task.loc.json
@@ -218,6 +218,15 @@
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.replaceExpression",
       "visibleRule": "versionCodeFilterType = expression"
+    },
+    {
+      "name": "changesNotSentForReview",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.changesNotSentForReview",
+      "groupName": "advanced",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.changesNotSentForReview"
     }
   ],
   "execution": {

--- a/Tasks/GooglePlayReleaseBundle/task.loc.json
+++ b/Tasks/GooglePlayReleaseBundle/task.loc.json
@@ -14,8 +14,8 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "187",
-    "Patch": "1"
+    "Minor": "188",
+    "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
   "groups": [


### PR DESCRIPTION
**Task name**: Google Play release bundle

**Description**: 
Added new input changesNotSentForReview. If the customer selects this option, changes will be sent to review.

I used the **@ts-ignore** comment because we don't have **changesNotSentForReview** option in edtits.commit method yet.
The changes for that option were added to the repo but the package with them has not released. [info](https://github.com/googleapis/google-api-nodejs-client/commit/a2ca59d046ebb7381c68298ad81edb80a84d6bcf#diff-d6bb74fc5fb7d9b91b45bc68d11d38099ee2fff3dcb853d27e2713ca2d5aa7bfR1967). 
With **@ts-ignore** all goes well.

I think we couldn't reproduce this issue because we didn't have any rejections in Google Play Console and all our changes were send automatically. The customer had ones and it probably affected to process. [Customer comment](https://github.com/microsoft/google-play-vsts-extension/issues/270#issuecomment-840684850).
[More info](https://support.google.com/googleplay/android-developer/answer/9859654?hl=en).

More info:
[About changesNotSentForReview parameter](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters)
About this error:
Here is an example of how a similar problem was solved:
[link#1](https://docs.codemagic.io/publishing-yaml/distribution/)
[link#2](https://docs.codemagic.io/publishing/publishing-to-google-play/)
About how rejection can affect to review process you can find [here](https://support.google.com/googleplay/android-developer/answer/9859654?hl=en)

**Documentation changes required:** https://github.com/microsoft/google-play-vsts-extension/tree/users/VladislavRyzhov/updateReadMe

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/google-play-vsts-extension/issues/270

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
