### PR TITLE
[GooglePlayReleaseBundle] Add input parameter to define Release-Name

### DIFF
--- a/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
+++ b/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
@@ -50,6 +50,7 @@ async function run() {
             versionCodeFilter = tl.getInput('replaceExpression', true);
         }
 
+        const releaseName: string = tl.getInput('releaseName', false);
         const track: string = tl.getInput('track', true);
         const userFractionSupplied: boolean = tl.getBoolInput('rolloutToUserFraction');
         const userFraction: number = Number(userFractionSupplied ? tl.getInput('userFraction', false) : 1.0);
@@ -132,7 +133,7 @@ async function run() {
 
         console.log(tl.loc('UpdateTrack'));
         tl.debug(`Updating the track ${track}.`);
-        const updatedTrack: pub3.Schema$Track = await updateTrack(edits, packageName, track, '' + bundleVersionCode, versionCodeFilterType, versionCodeFilter, userFraction, updatePriority, releaseNotes);
+        const updatedTrack: pub3.Schema$Track = await updateTrack(edits, packageName, track, '' + bundleVersionCode, versionCodeFilterType, versionCodeFilter, userFraction, updatePriority, releaseNotes, releaseName);
         tl.debug('Updated track info: ' + JSON.stringify(updatedTrack));
 
         tl.debug('Committing the edit transaction in Google Play.');
@@ -173,7 +174,8 @@ async function updateTrack(
     versionCodeFilter: string | string[],
     userFraction: number,
     updatePriority: number,
-    releaseNotes?: pub3.Schema$LocalizedText[]): Promise<pub3.Schema$Track> {
+    releaseNotes?: pub3.Schema$LocalizedText[],
+    releaseName?: string): Promise<pub3.Schema$Track> {
 
     let newTrackVersionCodes: string[] = [];
     let res: pub3.Schema$Track;
@@ -220,7 +222,7 @@ async function updateTrack(
 
     tl.debug(`New ${track} track version codes: ` + JSON.stringify(newTrackVersionCodes));
     try {
-        res = await googleutil.updateTrack(edits, packageName, track, newTrackVersionCodes, userFraction, updatePriority, releaseNotes);
+        res = await googleutil.updateTrack(edits, packageName, track, newTrackVersionCodes, userFraction, updatePriority, releaseNotes, releaseName);
     } catch (e) {
         tl.debug(`Failed to update track ${track}.`);
         tl.debug(e);

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -34,6 +34,8 @@
   "loc.input.help.shouldUploadMappingFile": "Select this option to attach your proguard mapping.txt file to the primary APK.",
   "loc.input.label.mappingFilePath": "Deobfuscation path",
   "loc.input.help.mappingFilePath": "The path to the proguard mapping.txt file to upload.",
+  "loc.input.label.releaseName": "Release name",
+  "loc.input.help.releaseName": "The release name is only for use in Play Console and won't be visible to users. To make your release easier to identify, add a release name that's meaningful to you.",
   "loc.input.label.versionCodeFilterType": "Replace version codes",
   "loc.input.help.versionCodeFilterType": "Specify version codes to replace in the selected track with the new APKs: all, the comma separated list, or a regular expression pattern.",
   "loc.input.label.replaceList": "Version code list",

--- a/Tasks/GooglePlayReleaseBundle/Tests/L0.ts
+++ b/Tasks/GooglePlayReleaseBundle/Tests/L0.ts
@@ -11,6 +11,10 @@ describe('L0 Suite google-play-release-bundle', function () {
         done();
     });
 
+    describe('googleutil updateTrack tests', function() {
+        require('./L0GoogleUtil');
+    });
+
     it('test no service endpoint fails', (done) => {
         const testFile = path.join(__dirname, 'L0NoServiceEndpoint.js');
         const testRunner = new ttm.MockTestRunner(testFile);

--- a/Tasks/GooglePlayReleaseBundle/Tests/L0GoogleUtil.ts
+++ b/Tasks/GooglePlayReleaseBundle/Tests/L0GoogleUtil.ts
@@ -1,0 +1,60 @@
+import * as assert from 'assert';
+import * as mockery from 'mockery';
+import * as sinon from 'sinon';
+
+import * as mockTask from 'azure-pipelines-task-lib/mock-task';
+import * as googleutil from '../googleutil';
+
+before(function () {
+    mockery.enable({
+        useCleanCache: true,
+        warnOnUnregistered: false
+    });
+});
+
+after(function () {
+    mockery.disable();
+});
+
+afterEach(function () {
+    mockery.deregisterAll();
+    mockery.resetCache();
+});
+
+it('updateTrack tests', async function () {
+    mockery.registerMock('azure-pipelines-task-lib/task', mockTask);
+    mockery.registerMock('googleapis', {
+        google: {
+            androidpublisher: () => ({})
+        }
+    });
+
+    const stub = sinon.stub();
+    const edits: any = { tracks: { update: stub } };
+
+    const packname = 'myPackageName';
+    const track = 'myFakeTrack';
+    const releaseName = 'myReleaseName';
+
+    stub.returns({ data: {}});
+    await googleutil.updateTrack(edits, packname, track, '123', 1.0, 0, null, releaseName);
+    assert(stub.called);
+    let response = stub.args[0][0];
+    assert.strictEqual(packname, response.packageName);
+    assert.strictEqual(track, response.track);
+    assert.strictEqual(1, response.requestBody.releases[0].versionCodes.length);
+    assert(!response.requestBody.releases[0].userFraction);
+    assert.strictEqual(releaseName, response.requestBody.releases[0].name);
+    assert.strictEqual('completed', response.requestBody.releases[0].status);
+    stub.reset();
+
+    stub.returns({ data: {}});
+    await googleutil.updateTrack(edits, packname, track, ['123', '345'], 0.9, 0, null, releaseName);
+    assert(stub.called);
+    response = stub.args[0][0];
+    assert.strictEqual(2, response.requestBody.releases[0].versionCodes.length);
+    assert.strictEqual(0.9, response.requestBody.releases[0].userFraction);
+    assert.strictEqual(releaseName, response.requestBody.releases[0].name);
+    assert.strictEqual('inProgress', response.requestBody.releases[0].status);
+    stub.reset();
+});

--- a/Tasks/GooglePlayReleaseBundle/googleutil.ts
+++ b/Tasks/GooglePlayReleaseBundle/googleutil.ts
@@ -121,12 +121,17 @@ export async function getTrack(edits: pub3.Resource$Edits, packageName: string, 
  * @returns {Promise} track - A promise that will return result from updating a track
  *                            { track: string, versionCodes: [integer], userFraction: double }
  */
-export async function updateTrack(edits: pub3.Resource$Edits, packageName: string, track: string, versionCode: string | string[], userFraction: number, updatePriority: number, releaseNotes?: pub3.Schema$LocalizedText[]): Promise<pub3.Schema$Track> {
+export async function updateTrack(edits: pub3.Resource$Edits, packageName: string, track: string, versionCode: string | string[], userFraction: number, updatePriority: number, releaseNotes?: pub3.Schema$LocalizedText[], releaseName?: string): Promise<pub3.Schema$Track> {
     tl.debug('Updating track');
     const release: pub3.Schema$TrackRelease = {
         versionCodes: (Array.isArray(versionCode) ? versionCode : [versionCode]),
         inAppUpdatePriority: updatePriority
     };
+
+    if (releaseName && releaseName.length > 0) {
+        tl.debug('Add release name: ' + releaseName);
+        release.name = releaseName;
+    }
 
     if (releaseNotes && releaseNotes.length > 0) {
         tl.debug('Attaching release notes to the update');

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "189",
+        "Minor": "191",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -184,6 +184,14 @@
             "required": false,
             "helpMarkDown": "The path to the proguard mapping.txt file to upload.",
             "visibleRule": "shouldUploadMappingFile = true"
+        },
+        {
+            "name": "releaseName",
+            "type": "string",
+            "label": "Release name",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "The release name is only for use in Play Console and won't be visible to users. To make your release easier to identify, add a release name that's meaningful to you."
         },
         {
             "name": "versionCodeFilterType",

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "191",
+        "Minor": "192",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseBundle/task.loc.json
+++ b/Tasks/GooglePlayReleaseBundle/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "191",
+    "Minor": "192",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseBundle/task.loc.json
+++ b/Tasks/GooglePlayReleaseBundle/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "189",
+    "Minor": "191",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -184,6 +184,14 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.mappingFilePath",
       "visibleRule": "shouldUploadMappingFile = true"
+    },
+    {
+      "name": "releaseName",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.releaseName",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.releaseName"
     },
     {
       "name": "versionCodeFilterType",


### PR DESCRIPTION
**Task name**: GooglePlayReleaseBundle

**Description**: Add input "Release Name" for Bundle Release task. 

**Documentation changes required:** (Y/N) Y

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) #257 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
