### PR TITLE
Fix taken GooglePlayStatusUpdate task guid; bump extension version

### DIFF
--- a/Tasks/GooglePlayStatusUpdate/task.json
+++ b/Tasks/GooglePlayStatusUpdate/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "5bc43cb5-dcbb-4d54-b752-b34147e7ce34",
+    "id": "92e6c372-4193-44e5-9db7-58d7d253f4d8",
     "name": "GooglePlayStatusUpdate",
     "friendlyName": "Google Play - Status Update",
     "description": "Update status of an app previously deployed to the Google Play Store",

--- a/Tasks/GooglePlayStatusUpdate/task.loc.json
+++ b/Tasks/GooglePlayStatusUpdate/task.loc.json
@@ -1,5 +1,5 @@
 {
-  "id": "5bc43cb5-dcbb-4d54-b752-b34147e7ce34",
+  "id": "92e6c372-4193-44e5-9db7-58d7d253f4d8",
   "name": "GooglePlayStatusUpdate",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "2.192.0",
+  "version": "2.192.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "2.192.0",
+  "version": "2.192.1",
   "description": "Provides build/release tasks that enable performing continuous delivery to the Google Play store from an automated VSTS build or release definition.",
   "repository": {
     "type": "git",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "3.192.0",
+    "version": "3.192.1",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
Looks like the there is already a task on the marketplace with the same guild as GooglePlayStatusUpdate; generated a new guid and bumped extension version