### PR TITLE
[GooglePlayReleaseV3, GooglePlayReleaseBundleV3] Add deprecation warnings

### DIFF
--- a/Tasks/GooglePlayRelease/GooglePlay.ts
+++ b/Tasks/GooglePlayRelease/GooglePlay.ts
@@ -11,6 +11,8 @@ async function run() {
     try {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
+        tl.warning(tl.loc('DeprecatedTask'));
+
         tl.debug('Prepare task inputs.');
 
         const authType: string = tl.getInput('authType', true);

--- a/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
@@ -48,7 +48,7 @@
   "loc.input.help.replaceList": "The comma separated list of APK version codes to be removed from the track with this deployment.",
   "loc.input.label.replaceExpression": "Version code pattern",
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
-  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
+  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 4.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainApk": "Found main APK to upload: %s (version code %s)",
   "loc.messages.FoundMultiApks": "Found multiple APKs to upload:",

--- a/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
@@ -48,6 +48,7 @@
   "loc.input.help.replaceList": "The comma separated list of APK version codes to be removed from the track with this deployment.",
   "loc.input.label.replaceExpression": "Version code pattern",
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
+  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a [migration guide here](https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md).",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainApk": "Found main APK to upload: %s (version code %s)",
   "loc.messages.FoundMultiApks": "Found multiple APKs to upload:",

--- a/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
@@ -48,7 +48,7 @@
   "loc.input.help.replaceList": "The comma separated list of APK version codes to be removed from the track with this deployment.",
   "loc.input.label.replaceExpression": "Version code pattern",
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
-  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md.",
+  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainApk": "Found main APK to upload: %s (version code %s)",
   "loc.messages.FoundMultiApks": "Found multiple APKs to upload:",

--- a/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayRelease/Strings/resources.resjson/en-US/resources.resjson
@@ -48,7 +48,7 @@
   "loc.input.help.replaceList": "The comma separated list of APK version codes to be removed from the track with this deployment.",
   "loc.input.label.replaceExpression": "Version code pattern",
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
-  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a [migration guide here](https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md).",
+  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md.",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainApk": "Found main APK to upload: %s (version code %s)",
   "loc.messages.FoundMultiApks": "Found multiple APKs to upload:",

--- a/Tasks/GooglePlayRelease/task.json
+++ b/Tasks/GooglePlayRelease/task.json
@@ -269,7 +269,7 @@
         }
     },
     "messages": {
-        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
+        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 4.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
         "InvalidAuthFile": "%s is not a valid auth file",
         "FoundMainApk": "Found main APK to upload: %s (version code %s)",
         "FoundMultiApks": "Found multiple APKs to upload:",

--- a/Tasks/GooglePlayRelease/task.json
+++ b/Tasks/GooglePlayRelease/task.json
@@ -269,7 +269,7 @@
         }
     },
     "messages": {
-        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a [migration guide here](https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md).",
+        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md.",
         "InvalidAuthFile": "%s is not a valid auth file",
         "FoundMainApk": "Found main APK to upload: %s (version code %s)",
         "FoundMultiApks": "Found multiple APKs to upload:",

--- a/Tasks/GooglePlayRelease/task.json
+++ b/Tasks/GooglePlayRelease/task.json
@@ -14,9 +14,10 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "189",
+        "Minor": "194",
         "Patch": "0"
     },
+    "deprecated": true,
     "minimumAgentVersion": "2.182.1",
     "groups": [
         {
@@ -268,6 +269,7 @@
         }
     },
     "messages": {
+        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a [migration guide here](https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md).",
         "InvalidAuthFile": "%s is not a valid auth file",
         "FoundMainApk": "Found main APK to upload: %s (version code %s)",
         "FoundMultiApks": "Found multiple APKs to upload:",

--- a/Tasks/GooglePlayRelease/task.json
+++ b/Tasks/GooglePlayRelease/task.json
@@ -269,7 +269,7 @@
         }
     },
     "messages": {
-        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md.",
+        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
         "InvalidAuthFile": "%s is not a valid auth file",
         "FoundMainApk": "Found main APK to upload: %s (version code %s)",
         "FoundMultiApks": "Found multiple APKs to upload:",

--- a/Tasks/GooglePlayRelease/task.loc.json
+++ b/Tasks/GooglePlayRelease/task.loc.json
@@ -14,9 +14,10 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "189",
+    "Minor": "194",
     "Patch": "0"
   },
+  "deprecated": true,
   "minimumAgentVersion": "2.182.1",
   "groups": [
     {
@@ -268,6 +269,7 @@
     }
   },
   "messages": {
+    "DeprecatedTask": "ms-resource:loc.messages.DeprecatedTask",
     "InvalidAuthFile": "ms-resource:loc.messages.InvalidAuthFile",
     "FoundMainApk": "ms-resource:loc.messages.FoundMainApk",
     "FoundMultiApks": "ms-resource:loc.messages.FoundMultiApks",

--- a/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
+++ b/Tasks/GooglePlayReleaseBundle/GooglePlay.ts
@@ -10,6 +10,8 @@ async function run() {
     try {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
+        tl.warning(tl.loc('DeprecatedTask'));
+
         tl.debug('Prepare task inputs.');
 
         const sendChangesToReview: boolean = tl.getBoolInput('changesNotSentForReview');

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -44,6 +44,7 @@
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
   "loc.input.label.changesNotSentForReview": "Send changes to review",
   "loc.input.help.changesNotSentForReview": "Select this option to send changes for review in GooglePlay Console. If changes're already sent for review automatically, you shouldn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters).",
+  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a [migration guide here](https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md).",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
   "loc.messages.FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -44,7 +44,7 @@
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
   "loc.input.label.changesNotSentForReview": "Send changes to review",
   "loc.input.help.changesNotSentForReview": "Select this option to send changes for review in GooglePlay Console. If changes're already sent for review automatically, you shouldn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters).",
-  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a [migration guide here](https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md).",
+  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md.",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
   "loc.messages.FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -44,7 +44,7 @@
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
   "loc.input.label.changesNotSentForReview": "Send changes to review",
   "loc.input.help.changesNotSentForReview": "Select this option to send changes for review in GooglePlay Console. If changes're already sent for review automatically, you shouldn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters).",
-  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
+  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 4.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
   "loc.messages.FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseBundle/Strings/resources.resjson/en-US/resources.resjson
@@ -44,7 +44,7 @@
   "loc.input.help.replaceExpression": "The regular expression pattern to select a list of APK version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
   "loc.input.label.changesNotSentForReview": "Send changes to review",
   "loc.input.help.changesNotSentForReview": "Select this option to send changes for review in GooglePlay Console. If changes're already sent for review automatically, you shouldn't select this option. [More info](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit#query-parameters).",
-  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md.",
+  "loc.messages.DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
   "loc.messages.InvalidAuthFile": "%s is not a valid auth file",
   "loc.messages.FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
   "loc.messages.FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -250,7 +250,7 @@
         }
     },
     "messages": {
-        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
+        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 4.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
         "InvalidAuthFile": "%s is not a valid auth file",
         "FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
         "FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -14,9 +14,10 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "192",
+        "Minor": "194",
         "Patch": "0"
     },
+    "deprecated": true,
     "minimumAgentVersion": "2.182.1",
     "groups": [
         {
@@ -249,6 +250,7 @@
         }
     },
     "messages": {
+        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a [migration guide here](https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md).",
         "InvalidAuthFile": "%s is not a valid auth file",
         "FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
         "FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -250,7 +250,7 @@
         }
     },
     "messages": {
-        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md.",
+        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md",
         "InvalidAuthFile": "%s is not a valid auth file",
         "FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
         "FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/task.json
+++ b/Tasks/GooglePlayReleaseBundle/task.json
@@ -250,7 +250,7 @@
         }
     },
     "messages": {
-        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a [migration guide here](https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md).",
+        "DeprecatedTask": "This task is deprecated. Please switch to GooglePlayRelease@4 that will be released in extension version 3.195.0. You can find a migration guide here: https://github.com/microsoft/google-play-vsts-extension/blob/master/docs/google-play-release-migration.md.",
         "InvalidAuthFile": "%s is not a valid auth file",
         "FoundMainBundle": "Found main bundle to upload: %s (version code %s)",
         "FoundDeobfuscationFile": "Found deobfuscation (mapping) file: %s",

--- a/Tasks/GooglePlayReleaseBundle/task.loc.json
+++ b/Tasks/GooglePlayReleaseBundle/task.loc.json
@@ -14,9 +14,10 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "192",
+    "Minor": "194",
     "Patch": "0"
   },
+  "deprecated": true,
   "minimumAgentVersion": "2.182.1",
   "groups": [
     {
@@ -249,6 +250,7 @@
     }
   },
   "messages": {
+    "DeprecatedTask": "ms-resource:loc.messages.DeprecatedTask",
     "InvalidAuthFile": "ms-resource:loc.messages.InvalidAuthFile",
     "FoundMainBundle": "ms-resource:loc.messages.FoundMainBundle",
     "FoundDeobfuscationFile": "ms-resource:loc.messages.FoundDeobfuscationFile",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "3.192.1",
+    "version": "3.194.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
**Task name**: GooglePlayReleaseV3, GooglePlayReleaseBundleV3

**Description**: Added deprecation warnings since we're planning to remove these tasks

**Documentation changes required:** Yes - prepare a migration guide

**Added unit tests:** No

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
