### PR TITLE
[GooglePlayReleaseV4] Fix task guid

### DIFF
--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "b0388a05-ace6-4d51-a99b-39356749e634",
+    "id": "8cf7cac0-620b-11e5-b4cf-8565e60f4d27",
     "name": "GooglePlayRelease",
     "friendlyName": "Google Play - Release",
     "description": "Release an app to the Google Play Store",

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -1,5 +1,5 @@
 {
-  "id": "b0388a05-ace6-4d51-a99b-39356749e634",
+  "id": "8cf7cac0-620b-11e5-b4cf-8565e60f4d27",
   "name": "GooglePlayRelease",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",


### PR DESCRIPTION
**Task name**: GooglePlayReleaseV4

**Description**: Set GUID the same as GooglePlayRelease@3 task.
The GooglePlayRelease@4 guid was invalid because we've been trying to upload this task along with GooglePlayReleaseV3 initially, and having the same guids didn't work.

**Documentation changes required:** No

**Added unit tests:** No

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it - not needed
- [x] Checked that applied changes work as expected
