### PR TITLE
Update documentation for releasing a bundle file

### DIFF
--- a/docs/google-play-release-migration.md
+++ b/docs/google-play-release-migration.md
@@ -58,7 +58,7 @@ The key difference is the "Action" input:
     serviceEndpoint: 'ServiceEndpointName'
     applicationId: 'com.org.appId'
     action: 'SingleBundle'
-    apkFile: '/path/to/application.aab'
+    bundleFile: '/path/to/application.aab'
     track: 'internal'
 ```
 


### PR DESCRIPTION
**Task name**: GooglePlayRelease

**Description**: The migration documentation for the GooglePlayRelease task mentions the wrong parameter in the 'Releasing a single bundle file' section; 'bundleFile' should be mentioned instead of 'apkFile'

**Documentation changes required:** N (Documentation change only)

**Added unit tests:** N (Documentation change only)

**Attached related issue:** #308

**Checklist**: (N/A)
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
