### PR TITLE
Fix error while updating from version 3.194.0 to 4.195.1 on Azure DevOps Server

### DIFF
--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -12,7 +12,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "194",
+        "Minor": "196",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -176,8 +176,7 @@
             "defaultValue": false,
             "type": "boolean",
             "helpMarkDown": "Change the in-app update priority value.",
-            "visibleRule": "action != OnlyStoreListing",
-            "groupName": "advanced"
+            "visibleRule": "action != OnlyStoreListing"
         },
         {
             "name": "updatePriority",
@@ -187,7 +186,6 @@
             "type": "pickList",
             "helpMarkDown": "Set a custom in-app update priority value to help keep your app up-to-date on your users' devices. To determine priority, Google Play uses an integer value between 0 and 5, with 0 being the default, and 5 being the highest priority. Priority can only be set when rolling out a new release, and cannot be changed later.",
             "visibleRule": "action != OnlyStoreListing && changeUpdatePriority = true",
-            "groupName": "advanced",
             "options": {
                 "0": "0",
                 "1": "1",
@@ -203,8 +201,7 @@
             "defaultValue": false,
             "type": "boolean",
             "helpMarkDown": "Roll out the release to a percentage of users.",
-            "visibleRule": "action != OnlyStoreListing",
-            "groupName": "advanced"
+            "visibleRule": "action != OnlyStoreListing"
         },
         {
             "name": "userFraction",
@@ -213,8 +210,7 @@
             "required": true,
             "type": "string",
             "helpMarkDown": "The percentage of users the specified application will be released to for the specified 'Track'. It can be increased later with the 'Google Play - Increase Rollout' task.",
-            "visibleRule": "action != OnlyStoreListing && rolloutToUserFraction = true",
-            "groupName": "advanced"
+            "visibleRule": "action != OnlyStoreListing && rolloutToUserFraction = true"
         },
         {
             "name": "shouldUploadMappingFile",
@@ -222,8 +218,7 @@
             "defaultValue": false,
             "type": "boolean",
             "helpMarkDown": "Select this option to attach your proguard mapping.txt file to your aab/apk.",
-            "visibleRule": "action != OnlyStoreListing && action != MultiApkAab",
-            "groupName": "advanced"
+            "visibleRule": "action != OnlyStoreListing && action != MultiApkAab"
         },
         {
             "name": "mappingFilePath",
@@ -232,8 +227,7 @@
             "required": true,
             "type": "string",
             "helpMarkDown": "The path to the proguard mapping.txt file to upload. Glob patterns are supported.",
-            "visibleRule": "action != OnlyStoreListing && action != MultiApkAab && shouldUploadMappingFile = true",
-            "groupName": "advanced"
+            "visibleRule": "action != OnlyStoreListing && action != MultiApkAab && shouldUploadMappingFile = true"
         },
         {
             "name": "changesNotSentForReview",
@@ -249,8 +243,7 @@
             "label": "Release name",
             "defaultValue": "",
             "helpMarkDown": "The release name is only for use in Play Console and won't be visible to users. To make your release easier to identify, add a release name that's meaningful to you.",
-            "visibleRule": "action != OnlyStoreListing",
-            "groupName": "advanced"
+            "visibleRule": "action != OnlyStoreListing"
         },
         {
             "name": "versionCodeFilterType",
@@ -259,7 +252,6 @@
             "type": "pickList",
             "helpMarkDown": "Specify version codes to replace in the selected track with the new aab(s)/apk(s): all, the comma separated list, or a regular expression pattern.",
             "visibleRule": "action != OnlyStoreListing",
-            "groupName": "advanced",
             "options": {
                 "all": "All",
                 "list": "List",
@@ -273,8 +265,7 @@
             "required": true,
             "type": "string",
             "helpMarkDown": "The comma separated list of version codes to be removed from the track with this deployment.",
-            "visibleRule": "action != OnlyStoreListing && versionCodeFilterType = list",
-            "groupName": "advanced"
+            "visibleRule": "action != OnlyStoreListing && versionCodeFilterType = list"
         },
         {
             "name": "replaceExpression",
@@ -283,8 +274,7 @@
             "required": true,
             "type": "string",
             "helpMarkDown": "The regular expression pattern to select a list of version codes to be removed from the track with this deployment, e.g. _.\\*12?(3|4)?5_ ",
-            "visibleRule": "action != OnlyStoreListing && versionCodeFilterType = expression",
-            "groupName": "advanced"
+            "visibleRule": "action != OnlyStoreListing && versionCodeFilterType = expression"
         }
     ],
     "execution": {

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -12,7 +12,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "194",
+    "Minor": "196",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -176,8 +176,7 @@
       "defaultValue": false,
       "type": "boolean",
       "helpMarkDown": "ms-resource:loc.input.help.changeUpdatePriority",
-      "visibleRule": "action != OnlyStoreListing",
-      "groupName": "advanced"
+      "visibleRule": "action != OnlyStoreListing"
     },
     {
       "name": "updatePriority",
@@ -187,7 +186,6 @@
       "type": "pickList",
       "helpMarkDown": "ms-resource:loc.input.help.updatePriority",
       "visibleRule": "action != OnlyStoreListing && changeUpdatePriority = true",
-      "groupName": "advanced",
       "options": {
         "0": "0",
         "1": "1",
@@ -203,8 +201,7 @@
       "defaultValue": false,
       "type": "boolean",
       "helpMarkDown": "ms-resource:loc.input.help.rolloutToUserFraction",
-      "visibleRule": "action != OnlyStoreListing",
-      "groupName": "advanced"
+      "visibleRule": "action != OnlyStoreListing"
     },
     {
       "name": "userFraction",
@@ -213,8 +210,7 @@
       "required": true,
       "type": "string",
       "helpMarkDown": "ms-resource:loc.input.help.userFraction",
-      "visibleRule": "action != OnlyStoreListing && rolloutToUserFraction = true",
-      "groupName": "advanced"
+      "visibleRule": "action != OnlyStoreListing && rolloutToUserFraction = true"
     },
     {
       "name": "shouldUploadMappingFile",
@@ -222,8 +218,7 @@
       "defaultValue": false,
       "type": "boolean",
       "helpMarkDown": "ms-resource:loc.input.help.shouldUploadMappingFile",
-      "visibleRule": "action != OnlyStoreListing && action != MultiApkAab",
-      "groupName": "advanced"
+      "visibleRule": "action != OnlyStoreListing && action != MultiApkAab"
     },
     {
       "name": "mappingFilePath",
@@ -232,8 +227,7 @@
       "required": true,
       "type": "string",
       "helpMarkDown": "ms-resource:loc.input.help.mappingFilePath",
-      "visibleRule": "action != OnlyStoreListing && action != MultiApkAab && shouldUploadMappingFile = true",
-      "groupName": "advanced"
+      "visibleRule": "action != OnlyStoreListing && action != MultiApkAab && shouldUploadMappingFile = true"
     },
     {
       "name": "changesNotSentForReview",
@@ -249,8 +243,7 @@
       "label": "ms-resource:loc.input.label.releaseName",
       "defaultValue": "",
       "helpMarkDown": "ms-resource:loc.input.help.releaseName",
-      "visibleRule": "action != OnlyStoreListing",
-      "groupName": "advanced"
+      "visibleRule": "action != OnlyStoreListing"
     },
     {
       "name": "versionCodeFilterType",
@@ -259,7 +252,6 @@
       "type": "pickList",
       "helpMarkDown": "ms-resource:loc.input.help.versionCodeFilterType",
       "visibleRule": "action != OnlyStoreListing",
-      "groupName": "advanced",
       "options": {
         "all": "All",
         "list": "List",
@@ -273,8 +265,7 @@
       "required": true,
       "type": "string",
       "helpMarkDown": "ms-resource:loc.input.help.replaceList",
-      "visibleRule": "action != OnlyStoreListing && versionCodeFilterType = list",
-      "groupName": "advanced"
+      "visibleRule": "action != OnlyStoreListing && versionCodeFilterType = list"
     },
     {
       "name": "replaceExpression",
@@ -283,8 +274,7 @@
       "required": true,
       "type": "string",
       "helpMarkDown": "ms-resource:loc.input.help.replaceExpression",
-      "visibleRule": "action != OnlyStoreListing && versionCodeFilterType = expression",
-      "groupName": "advanced"
+      "visibleRule": "action != OnlyStoreListing && versionCodeFilterType = expression"
     }
   ],
   "execution": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "4.195.1",
+  "version": "4.196.0",
   "description": "Provides build/release tasks that enable performing continuous delivery to the Google Play store from an automated VSTS build or release definition.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: GooglePlayReleaseV4

**Description**: Move input fields, that have dependency on "action" input, out of "advanced" group to fix error: 
`Task definition input 'action' and Task definition input 'changeUpdatePriority' must belong to same group as they are dependent inputs for Task with ID '8cf7cac0-620b-11e5-b4cf-8565e60f4d27' `

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/google-play-vsts-extension/issues/311

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

I have tested this fix on Azure DevOps Server 2020 and Azure DevOps Server 2019.
I have tried to install Google Play extension 4.195.1 (without fix) to my local instance and got the same error, then I applied my fix, generated my private package with extension and uploaded it to my instance of Azure DevOps Server 2020. It passed successfully and I was able to create pipeline with new version of task from my extension.