### PR TITLE
Add support default.txt changelog name

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ $(Specified Directory)
      |  └ wearScreenshots
      |     └ *.png || *.jpg || *.jpeg
      └ changelogs
-       └ $(versioncodes).txt
+       ├ $(versioncodes).txt
+       └ default.txt
 ```
 
 11. **Release Notes** *(File path)* - Path to the file specifying the release notes for the release you are publishing. Only visible if `Update metadata` option is disabled.

--- a/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
@@ -63,16 +63,16 @@ async function addAllReleaseNotes(versionCodes: number[], languageCode: string, 
     const releaseNotes: pub3.Schema$LocalizedText[] = [];
     for (const changelogFile of changelogs) {
         const changelogName: string = path.basename(changelogFile, path.extname(changelogFile));
-        const changelogVersion: number = parseInt(changelogName, 10);
-        if (!isNaN(changelogVersion) && (versionCodes.indexOf(changelogVersion) !== -1)) {
+        const changelogNameParsedInt: number = parseInt(changelogName, 10);
+        if ((!isNaN(changelogNameParsedInt) && (versionCodes.indexOf(changelogNameParsedInt) !== -1)) || (changelogName == 'default')) {
             const fullChangelogPath: string = path.join(changelogDir, changelogFile);
-
+            
             console.log(tl.loc('AppendChangelog', fullChangelogPath));
             releaseNotes.push({
                 language: languageCode,
                 text: getChangelog(fullChangelogPath)
             });
-            tl.debug(`Found release notes version ${changelogVersion} from ${fullChangelogPath} for language code ${languageCode}`);
+            tl.debug(`Found release notes version ${changelogName} from ${fullChangelogPath} for language code ${languageCode}`);
         } else {
             tl.debug(`The name of the file ${changelogFile} is not a valid version code. Skipping it.`);
         }

--- a/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
@@ -96,7 +96,11 @@ async function addAllReleaseNotes(versionCodes: number[], languageCode: string, 
  * @param {string} message Message to display after appending of new changelog object to array
  * @returns nothing
  */
-async function appendChangelogToReleaseNotes(changelogPath: string, releaseNotes: pub3.Schema$LocalizedText[], languageCode: string, message: string) {
+async function appendChangelogToReleaseNotes(
+    changelogPath: string,
+    releaseNotes: pub3.Schema$LocalizedText[],
+    languageCode: string,
+    message: string): Promise<void> {
     console.log(tl.loc('AppendChangelog', changelogPath));
     releaseNotes.push({
         language: languageCode,

--- a/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
@@ -64,9 +64,8 @@ async function addAllReleaseNotes(versionCodes: number[], languageCode: string, 
     for (const changelogFile of changelogs) {
         const changelogName: string = path.basename(changelogFile, path.extname(changelogFile));
         const changelogNameParsedInt: number = parseInt(changelogName, 10);
-        if ((!isNaN(changelogNameParsedInt) && (versionCodes.indexOf(changelogNameParsedInt) !== -1)) || (changelogName == 'default')) {
+        if (!isNaN(changelogNameParsedInt) && (versionCodes.indexOf(changelogNameParsedInt) !== -1) || changelogName === 'default') {
             const fullChangelogPath: string = path.join(changelogDir, changelogFile);
-            
             console.log(tl.loc('AppendChangelog', fullChangelogPath));
             releaseNotes.push({
                 language: languageCode,

--- a/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
@@ -67,6 +67,7 @@ async function addAllReleaseNotes(versionCodes: number[], languageCode: string, 
         const changelogVersion: number = parseInt(changelogName, 10);
         if (changelogName === 'default') {
             fullDefaultChangelogPath = path.join(changelogDir, changelogFile);
+            continue;
         }
 
         if (!isNaN(changelogVersion) && (versionCodes.indexOf(changelogVersion) !== -1)) {

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -12,7 +12,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "201",
+        "Minor": "203",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -12,7 +12,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "201",
+    "Minor": "203",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/baseREADME.md
+++ b/baseREADME.md
@@ -161,7 +161,8 @@ $(Specified Directory)
      |  └ wearScreenshots
      |     └ *.png || *.jpg || *.jpeg
      └ changelogs
-       └ $(versioncodes).txt
+       ├ $(versioncodes).txt
+       └ default.txt
 ```
 
 11. **Release Notes** *(File path)* - Path to the file specifying the release notes for the release you are publishing. Only visible if `Update metadata` option is disabled.

--- a/docs/vsts-README.md
+++ b/docs/vsts-README.md
@@ -165,7 +165,8 @@ $(Specified Directory)
      |  └ wearScreenshots
      |     └ *.png || *.jpg || *.jpeg
      └ changelogs
-       └ $(versioncodes).txt
+       ├ $(versioncodes).txt
+       └ default.txt
 ```
 
 11. **Release Notes** *(File path)* - Path to the file specifying the release notes for the release you are publishing. Only visible if `Update metadata` option is disabled.


### PR DESCRIPTION
**Task name**: GooglePlayReleaseV4

**Description**: The changes adds default.txt changelog file to list of required changelog files for uploading.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

Checked test cases:
1. there is no files in changelogs directory - no one changelog is uploaded with metadata
2. there is file with name different from version number only - no one changelog is uploaded with metadata
3. there is file default.txt only - file default.txt is used as changelog
4. there is file with name equal to version number only - file with name equal to version number is used as changelog
5. there are 2 files: default.txt and file with name equal to version number - file with name equal to version number is used as changelog