### PR TITLE
Added helpMarkDown to GPlay extension tasks

### DIFF
--- a/Tasks/GooglePlayIncreaseRolloutV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayIncreaseRolloutV2/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,6 @@
 {
   "loc.friendlyName": "Google Play - Increase Rollout",
+  "loc.helpMarkDown": "[Learn more about this task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)",
   "loc.description": "Increase the rollout fraction of an app previously deployed to the Google Play Store",
   "loc.instanceNameFormat": "Increase $(packageName) rollout fraction to $(userFraction)",
   "loc.input.label.authType": "Authentication method",

--- a/Tasks/GooglePlayIncreaseRolloutV2/task.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/task.json
@@ -3,6 +3,8 @@
     "name": "GooglePlayIncreaseRollout",
     "friendlyName": "Google Play - Increase Rollout",
     "description": "Increase the rollout fraction of an app previously deployed to the Google Play Store",
+    "helpUrl": "https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play",
+    "helpMarkDown": "[Learn more about this task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)",
     "author": "Microsoft Corporation",
     "category": "Deploy",
     "visibility": [
@@ -11,8 +13,8 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "208",
-        "Patch": "1"
+        "Minor": "211",
+        "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Increase $(packageName) rollout fraction to $(userFraction)",

--- a/Tasks/GooglePlayIncreaseRolloutV2/task.loc.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/task.loc.json
@@ -3,6 +3,8 @@
   "name": "GooglePlayIncreaseRollout",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
+  "helpUrl": "https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play",
+  "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "author": "Microsoft Corporation",
   "category": "Deploy",
   "visibility": [
@@ -11,7 +13,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "208",
+    "Minor": "211",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -114,6 +116,5 @@
     "settableVariables": {
       "allowed": []
     }
-  },
-  "helpMarkDown": "ms-resource:loc.helpMarkDown"
+  }
 }

--- a/Tasks/GooglePlayPromoteV3/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayPromoteV3/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,6 @@
 {
   "loc.friendlyName": "Google Play - Promote",
+  "loc.helpMarkDown": "[Learn more about this task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)",
   "loc.description": "Promote an app from one release track to another",
   "loc.instanceNameFormat": "Promote $(packageName) from $(sourceTrack) to $(destinationTrack)",
   "loc.input.label.authType": "Authentication method",

--- a/Tasks/GooglePlayPromoteV3/task.json
+++ b/Tasks/GooglePlayPromoteV3/task.json
@@ -3,6 +3,8 @@
     "name": "GooglePlayPromote",
     "friendlyName": "Google Play - Promote",
     "description": "Promote an app from one release track to another",
+    "helpUrl": "https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play",
+    "helpMarkDown": "[Learn more about this task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)",
     "author": "Microsoft Corporation",
     "category": "Deploy",
     "visibility": [
@@ -11,7 +13,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "208",
+        "Minor": "211",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayPromoteV3/task.loc.json
+++ b/Tasks/GooglePlayPromoteV3/task.loc.json
@@ -3,6 +3,8 @@
   "name": "GooglePlayPromote",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
+  "helpUrl": "https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play",
+  "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "author": "Microsoft Corporation",
   "category": "Deploy",
   "visibility": [
@@ -11,7 +13,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "208",
+    "Minor": "211",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -159,6 +161,5 @@
     "settableVariables": {
       "allowed": []
     }
-  },
-  "helpMarkDown": "ms-resource:loc.helpMarkDown"
+  }
 }

--- a/Tasks/GooglePlayReleaseV4/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayReleaseV4/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,6 @@
 {
   "loc.friendlyName": "Google Play - Release",
+  "loc.helpMarkDown": "[Learn more about this task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)",
   "loc.description": "Release an app to the Google Play Store",
   "loc.instanceNameFormat": "Release $(applicationId) to $(track)",
   "loc.group.displayName.advanced": "Advanced Options",

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -3,6 +3,8 @@
     "name": "GooglePlayRelease",
     "friendlyName": "Google Play - Release",
     "description": "Release an app to the Google Play Store",
+    "helpUrl": "https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play",
+    "helpMarkDown": "[Learn more about this task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)",
     "author": "Microsoft Corporation",
     "category": "Deploy",
     "visibility": [
@@ -12,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "209",
+        "Minor": "211",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -3,6 +3,8 @@
   "name": "GooglePlayRelease",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
+  "helpUrl": "https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play",
+  "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "author": "Microsoft Corporation",
   "category": "Deploy",
   "visibility": [
@@ -12,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "209",
+    "Minor": "211",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -348,6 +350,5 @@
     "settableVariables": {
       "allowed": []
     }
-  },
-  "helpMarkDown": "ms-resource:loc.helpMarkDown"
+  }
 }

--- a/Tasks/GooglePlayStatusUpdateV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GooglePlayStatusUpdateV2/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,6 @@
 {
   "loc.friendlyName": "Google Play - Status Update",
+  "loc.helpMarkDown": "[Learn more about this task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)",
   "loc.description": "Update status of an app previously deployed to the Google Play Store",
   "loc.instanceNameFormat": "Update $(packageName) status to $(status)",
   "loc.input.label.authType": "Authentication method",

--- a/Tasks/GooglePlayStatusUpdateV2/task.json
+++ b/Tasks/GooglePlayStatusUpdateV2/task.json
@@ -3,6 +3,8 @@
     "name": "GooglePlayStatusUpdate",
     "friendlyName": "Google Play - Status Update",
     "description": "Update status of an app previously deployed to the Google Play Store",
+    "helpUrl": "https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play",
+    "helpMarkDown": "[Learn more about this task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)",
     "author": "Microsoft Corporation",
     "category": "Deploy",
     "visibility": [
@@ -11,7 +13,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "207",
+        "Minor": "211",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayStatusUpdateV2/task.loc.json
+++ b/Tasks/GooglePlayStatusUpdateV2/task.loc.json
@@ -3,6 +3,8 @@
   "name": "GooglePlayStatusUpdate",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
+  "helpUrl": "https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play",
+  "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "author": "Microsoft Corporation",
   "category": "Deploy",
   "visibility": [
@@ -11,7 +13,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "207",
+    "Minor": "211",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -127,6 +129,5 @@
     "settableVariables": {
       "allowed": []
     }
-  },
-  "helpMarkDown": "ms-resource:loc.helpMarkDown"
+  }
 }


### PR DESCRIPTION
**Task name**: Add helpMarkDown to GPlay extension tasks

**Description**: We have missing helpMarkDown and helpUrl property in task.json files. Added corresponding key-values and updated related files 

**Documentation changes required:**  N

**Added unit tests:**  N

**Attached related issue:**  [https://github.com/microsoft/build-task-team/issues/765](https://github.com/microsoft/build-task-team/issues/765)

**Checklist**:
- [x] Task version was bumped
- [x] Checked that applied changes work as expected
