### PR TITLE
Add support for multiple apk architectures + upload mapping

### DIFF
--- a/Tasks/GooglePlayReleaseV4/main.ts
+++ b/Tasks/GooglePlayReleaseV4/main.ts
@@ -66,7 +66,7 @@ async function run(): Promise<void> {
         const userFractionSupplied: boolean = tl.getBoolInput('rolloutToUserFraction');
         const userFraction: number = Number(userFractionSupplied ? tl.getInput('userFraction', false) : 1.0);
 
-        const uploadMappingFile: boolean = tl.getBoolInput('shouldUploadMappingFile', false) && (action === 'SingleApk' || action === 'SingleBundle');
+        const uploadMappingFile: boolean = tl.getBoolInput('shouldUploadMappingFile', false) && (action === 'SingleApk' || action === 'SingleBundle' || action === 'MultiApk');
         const mappingFilePattern: string = tl.getInput('mappingFilePath');
 
         const uploadNativeDebugSymbols: boolean = tl.getBoolInput('shouldUploadNativeDebugSymbols', false) && (action === 'SingleApk' || action === 'SingleBundle');
@@ -160,7 +160,9 @@ async function run(): Promise<void> {
             }
 
             if (uploadMappingFile) {
-                tl.debug(`Mapping file pattern: ${mappingFilePattern}`);
+                
+                if (versionCodes.length == 1) {
+                            tl.debug(`Mapping file pattern: ${mappingFilePattern}`);
 
                 const mappingFilePath = fileHelper.resolveGlobPath(mappingFilePattern);
                 tl.checkPath(mappingFilePath, 'Mapping file path');
@@ -168,7 +170,29 @@ async function run(): Promise<void> {
                 console.log(tl.loc('FoundDeobfuscationFile', mappingFilePath));
                 tl.debug(`Uploading ${mappingFilePath} for version code ${versionCodes[0]}`);
                 await googleutil.uploadDeobfuscation(edits, mappingFilePath, packageName, versionCodes[0]);
-            }
+                    
+                } else {
+                    
+                    for (const versionCode of versionCodes) {
+                     
+                        const mappingFilePath = fileHelper.resolveGlobPath(mappingFilePattern);
+                tl.checkPath(mappingFilePath, 'Mapping file path');
+
+                console.log(tl.loc('FoundDeobfuscationFile', mappingFilePath));
+                tl.debug(`Uploading ${mappingFilePath} for version code ${versionCode]}`);
+                await googleutil.uploadDeobfuscation(edits, mappingFilePath, packageName, versionCode);
+                        
+                        
+                    }
+                    
+                    
+                }
+                
+                
+        
+                
+                
+            } 
 
             if (uploadNativeDebugSymbols) {
                 tl.debug(`Native debug symbols file pattern: ${nativeDebugSymbolsFilePattern}`);

--- a/Tasks/GooglePlayReleaseV4/main.ts
+++ b/Tasks/GooglePlayReleaseV4/main.ts
@@ -161,19 +161,7 @@ async function run(): Promise<void> {
 
             if (uploadMappingFile) {
                 
-                if (versionCodes.length == 1) {
-                            tl.debug(`Mapping file pattern: ${mappingFilePattern}`);
-
-                const mappingFilePath = fileHelper.resolveGlobPath(mappingFilePattern);
-                tl.checkPath(mappingFilePath, 'Mapping file path');
-
-                console.log(tl.loc('FoundDeobfuscationFile', mappingFilePath));
-                tl.debug(`Uploading ${mappingFilePath} for version code ${versionCodes[0]}`);
-                await googleutil.uploadDeobfuscation(edits, mappingFilePath, packageName, versionCodes[0]);
-                    
-                } else {
-                    
-                    for (const versionCode of versionCodes) {
+                for (const versionCode of versionCodes) {
                      
                         const mappingFilePath = fileHelper.resolveGlobPath(mappingFilePattern);
                 tl.checkPath(mappingFilePath, 'Mapping file path');
@@ -184,12 +172,6 @@ async function run(): Promise<void> {
                         
                         
                     }
-                    
-                    
-                }
-                
-                
-        
                 
                 
             } 

--- a/Tasks/GooglePlayReleaseV4/modules/inputsHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/inputsHelper.ts
@@ -29,7 +29,7 @@ export function getClientKey(): googleutil.ClientKey {
     return key;
 }
 
-const actions = ['OnlyStoreListing', 'SingleBundle', 'SingleApk', 'MultiApkAab'] as const;
+const actions = ['OnlyStoreListing', 'SingleBundle', 'SingleApk', 'MultiApkAab',"MultiApk"] as const;
 export type Action = (typeof actions)[number];
 
 /**


### PR DESCRIPTION
**Task name**: Support for multi apk support + mapping. 

**Description**: We have a situation where we want to upload multiple apks and attach their associated mapping file to the apks.

**Documentation changes required:** (Y/N) <Y>

**Added unit tests:** (Y/N) <N>

**Attached related issue:** (Y/N) <N>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
