### PR TITLE
Remove secret from debug logs

### DIFF
--- a/Tasks/GooglePlayIncreaseRolloutV2/google-play-increase-rollout.ts
+++ b/Tasks/GooglePlayIncreaseRolloutV2/google-play-increase-rollout.ts
@@ -43,7 +43,7 @@ async function run() {
         googleutil.updateGlobalParams(globalParams, 'packageName', packageName);
 
         console.log(tl.loc('Authenticating'));
-        await jwtClient.authorize();
+        await googleutil.authorize(jwtClient);
         const edit = await googleutil.getNewEdit(edits, globalParams, packageName);
         googleutil.updateGlobalParams(globalParams, 'editId', edit.id);
 

--- a/Tasks/GooglePlayIncreaseRolloutV2/googleutil.ts
+++ b/Tasks/GooglePlayIncreaseRolloutV2/googleutil.ts
@@ -101,6 +101,19 @@ export function getJWT(key: ClientKey): JWT {
     return new google.auth.JWT(key.client_email, null, key.private_key, GOOGLE_PLAY_SCOPES, null);
 }
 
+export async function authorize(jwtClient: JWT): Promise<void> {
+    await jwtClient.authorize();
+
+    const credsToken: string = jwtClient.credentials.access_token;
+    const rawToken: string = jwtClient.gtoken.rawToken.access_token;
+
+    tl.setSecret(credsToken);
+
+    if (rawToken !== credsToken) {
+        tl.setSecret(rawToken);
+    }
+}
+
 /**
  * Uses the provided JWT client to request a new edit from the Play store and attach the edit id to all requests made this session
  * Assumes authorized

--- a/Tasks/GooglePlayIncreaseRolloutV2/task.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "220",
+        "Minor": "226",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayIncreaseRolloutV2/task.loc.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "220",
+    "Minor": "226",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayPromoteV3/google-play-promote.ts
+++ b/Tasks/GooglePlayPromoteV3/google-play-promote.ts
@@ -46,7 +46,7 @@ async function run() {
         googleutil.updateGlobalParams(globalParams, 'packageName', packageName);
 
         console.log(tl.loc('Authenticating'));
-        await jwtClient.authorize();
+        await googleutil.authorize(jwtClient);
         const edit = await googleutil.getNewEdit(edits, globalParams, packageName);
         googleutil.updateGlobalParams(globalParams, 'editId', edit.id);
 

--- a/Tasks/GooglePlayPromoteV3/googleutil.ts
+++ b/Tasks/GooglePlayPromoteV3/googleutil.ts
@@ -101,6 +101,19 @@ export function getJWT(key: ClientKey): JWT {
     return new google.auth.JWT(key.client_email, null, key.private_key, GOOGLE_PLAY_SCOPES, null);
 }
 
+export async function authorize(jwtClient: JWT): Promise<void> {
+    await jwtClient.authorize();
+
+    const credsToken: string = jwtClient.credentials.access_token;
+    const rawToken: string = jwtClient.gtoken.rawToken.access_token;
+
+    tl.setSecret(credsToken);
+
+    if (rawToken !== credsToken) {
+        tl.setSecret(rawToken);
+    }
+}
+
 /**
  * Uses the provided JWT client to request a new edit from the Play store and attach the edit id to all requests made this session
  * Assumes authorized

--- a/Tasks/GooglePlayPromoteV3/task.json
+++ b/Tasks/GooglePlayPromoteV3/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "220",
+        "Minor": "226",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayPromoteV3/task.loc.json
+++ b/Tasks/GooglePlayPromoteV3/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "220",
+    "Minor": "226",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseV4/main.ts
+++ b/Tasks/GooglePlayReleaseV4/main.ts
@@ -113,7 +113,7 @@ async function run(): Promise<void> {
         const edits: pub3.Resource$Edits = googleutil.publisher.edits;
 
         tl.debug('Authorize JWT.');
-        await jwtClient.authorize();
+        await googleutil.authorize(jwtClient);
 
         console.log(tl.loc('GetNewEditAfterAuth'));
         tl.debug('Creating a new edit transaction in Google Play.');

--- a/Tasks/GooglePlayReleaseV4/modules/googleutil.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/googleutil.ts
@@ -19,6 +19,19 @@ export function getJWT(key: ClientKey): googleapis.Auth.JWT {
     return new googleapis.Auth.JWT(key.client_email, null, key.private_key, GOOGLE_PLAY_SCOPES, null);
 }
 
+export async function authorize(jwtClient: googleapis.Auth.JWT): Promise<void> {
+    await jwtClient.authorize();
+
+    const credsToken: string = jwtClient.credentials.access_token;
+    const rawToken: string = jwtClient.gtoken.rawToken.access_token;
+
+    tl.setSecret(credsToken);
+
+    if (rawToken !== credsToken) {
+        tl.setSecret(rawToken);
+    }
+}
+
 /**
  * Uses the provided JWT client to request a new edit from the Play store and attach the edit id to all requests made this session
  * Assumes authorized

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "220",
+        "Minor": "226",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "220",
+    "Minor": "226",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayStatusUpdateV2/google-play-status-update.ts
+++ b/Tasks/GooglePlayStatusUpdateV2/google-play-status-update.ts
@@ -48,7 +48,7 @@ async function run() {
         googleutil.updateGlobalParams(globalParams, 'packageName', packageName);
 
         console.log(tl.loc('Authenticating'));
-        await jwtClient.authorize();
+        await googleutil.authorize(jwtClient);
         const edit: androidpublisher_v3.Schema$AppEdit = await googleutil.getNewEdit(edits, globalParams, packageName);
         googleutil.updateGlobalParams(globalParams, 'editId', edit.id);
 

--- a/Tasks/GooglePlayStatusUpdateV2/googleutil.ts
+++ b/Tasks/GooglePlayStatusUpdateV2/googleutil.ts
@@ -49,6 +49,19 @@ export function getJWT(key: ClientKey): JWT {
     return new google.auth.JWT(key.client_email, null, key.private_key, GOOGLE_PLAY_SCOPES, null);
 }
 
+export async function authorize(jwtClient: JWT): Promise<void> {
+    await jwtClient.authorize();
+
+    const credsToken: string = jwtClient.credentials.access_token;
+    const rawToken: string = jwtClient.gtoken.rawToken.access_token;
+
+    tl.setSecret(credsToken);
+
+    if (rawToken !== credsToken) {
+        tl.setSecret(rawToken);
+    }
+}
+
 /**
  * Uses the provided JWT client to request a new edit from the Play store and attach the edit id to all requests made this session
  * Assumes authorized

--- a/Tasks/GooglePlayStatusUpdateV2/task.json
+++ b/Tasks/GooglePlayStatusUpdateV2/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "220",
+        "Minor": "226",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayStatusUpdateV2/task.loc.json
+++ b/Tasks/GooglePlayStatusUpdateV2/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "220",
+    "Minor": "226",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "4.220.1",
+    "version": "4.226.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
**Tasks:**
* GooglePlayIncreaseRolloutV2
* GooglePlayPromoteV3
* GooglePlayReleaseV4
* GooglePlayStatusUpdateV2

**ChangeLog:** `googleutil.ts` — added the `authorize` function

**Description:** Remove secret from debug logs

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** No

**Checklist:**
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected — [Related Pipeline Run](https://buildcanary.visualstudio.com/CanaryBuilds/_build/results?buildId=3129322&view=logs&j=beefbc5b-a58b-56cd-443b-434a11f430b0&t=50ef1e9d-9469-5bfa-1718-ae1208528e57&l=108)