### PR TITLE
Fix `getJWT` and add `authorize` methods in unit tests

### DIFF
--- a/Tasks/GooglePlayIncreaseRolloutV2/Tests/L0GoogleAuthError.ts
+++ b/Tasks/GooglePlayIncreaseRolloutV2/Tests/L0GoogleAuthError.ts
@@ -16,14 +16,18 @@ tr.registerMock('./googleutil', {
     publisher: {
         edits: {}
     },
-    getJWT: () => {
-        return {
-            authorize: () => { throw new Error('authorize() error'); }
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.reject(new Error('authorize() error')),
     updateGlobalParams: () => sinon.stub()
 });
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.run();

--- a/Tasks/GooglePlayIncreaseRolloutV2/Tests/L0NothingInProgress.ts
+++ b/Tasks/GooglePlayIncreaseRolloutV2/Tests/L0NothingInProgress.ts
@@ -18,7 +18,8 @@ tr.registerMock('./googleutil', {
             commit: () => Promise.resolve({ data: {} })
         }
     },
-    getJWT: () => ({ authorize: () => sinon.stub() }),
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     updateGlobalParams: () => ({}),
     getNewEdit: () => Promise.resolve({}),
     updateTrack: () => Promise.resolve({}),
@@ -32,6 +33,13 @@ tr.registerMock('./googleutil', {
     })
 });
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.run();

--- a/Tasks/GooglePlayIncreaseRolloutV2/Tests/L0SendReleaseNotes.ts
+++ b/Tasks/GooglePlayIncreaseRolloutV2/Tests/L0SendReleaseNotes.ts
@@ -18,7 +18,8 @@ tr.registerMock('./googleutil', {
             commit: () => Promise.resolve({ data: {} })
         }
     },
-    getJWT: () => ({ authorize: () => sinon.stub() }),
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     updateGlobalParams: () => ({}),
     getNewEdit: () => Promise.resolve({}),
     updateTrack: (_edits, _packageName, _track, _versionCode, _userFraction, releaseNotes?) => Promise.resolve(releaseNotes),
@@ -35,6 +36,13 @@ tr.registerMock('./googleutil', {
     })
 });
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.run();

--- a/Tasks/GooglePlayPromoteV3/Tests/L0PromoteNoVersionCode.ts
+++ b/Tasks/GooglePlayPromoteV3/Tests/L0PromoteNoVersionCode.ts
@@ -19,7 +19,8 @@ tr.registerMock('./googleutil', {
             commit: () => Promise.resolve({ data: {} })
         }
     },
-    getJWT: () => ({ authorize: () => sinon.stub() }),
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     updateGlobalParams: () => ({}),
     getNewEdit: () => Promise.resolve({}),
 
@@ -46,6 +47,13 @@ tr.registerMock('./googleutil', {
     })
 });
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.run();

--- a/Tasks/GooglePlayPromoteV3/Tests/L0PromoteWithVersionCode.ts
+++ b/Tasks/GooglePlayPromoteV3/Tests/L0PromoteWithVersionCode.ts
@@ -20,7 +20,8 @@ tr.registerMock('./googleutil', {
             commit: () => Promise.resolve({ data: {} })
         }
     },
-    getJWT: () => ({ authorize: () => sinon.stub() }),
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     updateGlobalParams: () => ({}),
     getNewEdit: () => Promise.resolve({}),
     updateTrack: (_edits, _packageName, _track, _versionCode, _userFraction, releaseNotes?) => Promise.resolve({
@@ -47,6 +48,13 @@ tr.registerMock('./googleutil', {
     })
 });
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.run();

--- a/Tasks/GooglePlayPromoteV3/Tests/L0SendReleaseNotes.ts
+++ b/Tasks/GooglePlayPromoteV3/Tests/L0SendReleaseNotes.ts
@@ -19,7 +19,8 @@ tr.registerMock('./googleutil', {
             commit: () => Promise.resolve({ data: {} })
         }
     },
-    getJWT: () => ({ authorize: () => sinon.stub() }),
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     updateGlobalParams: () => ({}),
     getNewEdit: () => Promise.resolve({}),
     updateTrack: (_edits, _packageName, _track, _versionCode, _userFraction, releaseNotes?) => Promise.resolve(releaseNotes),
@@ -36,6 +37,13 @@ tr.registerMock('./googleutil', {
     })
 });
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.run();

--- a/Tasks/GooglePlayReleaseV4/Tests/L0AttachMetadata.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0AttachMetadata.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -37,11 +44,8 @@ tr.registerMock('./modules/googleutil', {
             }
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({ releases: [{ versionCodes: [1, 2, 3 ]}]}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0BadVersionList.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0BadVersionList.ts
@@ -6,7 +6,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');

--- a/Tasks/GooglePlayReleaseV4/Tests/L0DeobfuscationFileNotFound.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0DeobfuscationFileNotFound.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -32,11 +39,8 @@ tr.registerMock('./modules/googleutil', {
             commit: sinon.stub()
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0FoundDeobfuscationFile.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0FoundDeobfuscationFile.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -34,11 +41,8 @@ tr.registerMock('./modules/googleutil', {
             commit: sinon.stub()
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0HappyPath.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0HappyPath.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -30,11 +37,8 @@ tr.registerMock('./modules/googleutil', {
             commit: sinon.stub()
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0NoApkFound.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0NoApkFound.ts
@@ -5,7 +5,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');

--- a/Tasks/GooglePlayReleaseV4/Tests/L0NoApkSupplied.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0NoApkSupplied.ts
@@ -11,6 +11,13 @@ tr.setInput('applicationId', 'package');
 tr.setInput('action', 'SingleApk');
 tr.setInput('apkFile', '');
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.run();

--- a/Tasks/GooglePlayReleaseV4/Tests/L0ObbFileNotFound.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0ObbFileNotFound.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -32,11 +39,8 @@ tr.registerMock('./modules/googleutil', {
             commit: sinon.stub()
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({ releases: [{ versionCodes: [1, 2, 3 ]}]}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0ObbFoundInApkDirectory.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0ObbFoundInApkDirectory.ts
@@ -13,7 +13,14 @@ stubForReaddirSync.onFirstCall().returns(['/path/to/obbfolder/file.exe', '/path/
 stubForReaddirSync.onSecondCall().returns(['main.1.package.obb', '/path/to/obbfolder/filename.txt']);
 stubForReaddirSync.onThirdCall().returns(['main.1.package.obb', '/path/to/obbfolder/filename.txt']);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -38,11 +45,8 @@ tr.registerMock('./modules/googleutil', {
             commit: sinon.stub()
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({ releases: [{ versionCodes: [1, 2, 3 ]}]}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0ObbFoundInParentDirectory.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0ObbFoundInParentDirectory.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -32,11 +39,8 @@ tr.registerMock('./modules/googleutil', {
             commit: sinon.stub()
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({ releases: [{ versionCodes: [1, 2, 3 ]}]}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0UpdateTrackWithVersionList.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0UpdateTrackWithVersionList.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -38,11 +45,8 @@ tr.registerMock('./modules/googleutil', {
             }
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({ releases: [{ versionCodes: [1, 2, 3]}]}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0UseChangeLog.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0UseChangeLog.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -41,11 +48,8 @@ tr.registerMock('./modules/googleutil', {
             commit: sinon.stub()
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({ releases: [{ versionCodes: [1, 2, 3 ]}]}),
     updateTrack: () => Promise.resolve({}),

--- a/Tasks/GooglePlayReleaseV4/Tests/L0UseChangeLogFail.ts
+++ b/Tasks/GooglePlayReleaseV4/Tests/L0UseChangeLogFail.ts
@@ -7,7 +7,14 @@ import path = require('path');
 const taskPath = path.join(__dirname, '..', 'main.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_myServiceEndpoint'] = '{ "parameters": {"username": "myUser", "password": "myPass"}, "scheme": "UsernamePassword"}';
+process.env['ENDPOINT_AUTH_myServiceEndpoint'] = JSON.stringify({
+    parameters: {
+        username: 'myUser',
+        password: 'myPass'
+    },
+
+    scheme: 'UsernamePassword'
+});
 
 tr.setInput('authType', 'ServiceEndpoint');
 tr.setInput('serviceEndpoint', 'myServiceEndpoint');
@@ -40,11 +47,8 @@ tr.registerMock('./modules/googleutil', {
             commit: sinon.stub()
         }
     },
-    getJWT: () => {
-        return {
-            authorize: sinon.stub()
-        };
-    },
+    getJWT: () => ({ authorize: () => { throw new Error('JWT.authorize() should be run via googleutil.authorize(JWT)'); } }),
+    authorize: () => Promise.resolve(),
     getNewEdit: () => Promise.resolve({}),
     getTrack: () => Promise.resolve({}),
     updateTrack: () => Promise.resolve({}),


### PR DESCRIPTION
**Description:** Update unit tests according to changes from [the previous PR](https://github.com/microsoft/google-play-vsts-extension/pull/413).

**Documentation changes required:** No

**Added new unit tests:** tests will fail if the `jwtClient.authorize()` method will be run directly.

**Attached related issue:** No

**Checklist:**
- [x] Task versions do not need to be bumped
- [ ] Checked that applied changes work as expected
