### PR TITLE
The `versionCodes` property can be `undefined`

### DIFF
--- a/Tasks/GooglePlayReleaseV4/main.ts
+++ b/Tasks/GooglePlayReleaseV4/main.ts
@@ -350,7 +350,7 @@ async function prepareTrackUpdate({
         const versionCodesFromResponse: string[] = res.releases[0].versionCodes;
 
         if (!versionCodesFromResponse) {
-            console.log('Version codes do not exist for the latest completed release; nothing to remove.');
+            console.log('Version codes do not exist for the latest completed release; nothing to filter.');
             newTrackVersionCodes = versionCodes;
         } else {
             const oldTrackVersionCodes: number[] = versionCodesFromResponse.map((v) => Number(v));

--- a/Tasks/GooglePlayReleaseV4/main.ts
+++ b/Tasks/GooglePlayReleaseV4/main.ts
@@ -347,35 +347,43 @@ async function prepareTrackUpdate({
             throw new Error(tl.loc('CannotDownloadTrack', track, e));
         }
 
-        const oldTrackVersionCodes: number[] = res.releases[0].versionCodes.map((v) => Number(v));
-        tl.debug('Current version codes: ' + JSON.stringify(oldTrackVersionCodes));
+        const versionCodesFromResponse: string[] = res.releases[0].versionCodes;
 
-        if (typeof(versionCodeFilter) === 'string') {
-            tl.debug(`Removing version codes matching the regular expression: ^${versionCodeFilter}$`);
-            const versionCodesToRemove: RegExp = new RegExp(`^${versionCodeFilter}$`);
-
-            oldTrackVersionCodes.forEach((versionCode) => {
-                if (!versionCode.toString().match(versionCodesToRemove)) {
-                    newTrackVersionCodes.push(versionCode);
-                }
-            });
+        if (!versionCodesFromResponse) {
+            console.log('Version codes do not exist for the latest completed release; nothing to remove.');
+            newTrackVersionCodes = versionCodes;
         } else {
-            const versionCodesToRemove = versionCodeFilter;
-            tl.debug('Removing version codes: ' + JSON.stringify(versionCodesToRemove));
+            const oldTrackVersionCodes: number[] = versionCodesFromResponse.map((v) => Number(v));
 
-            oldTrackVersionCodes.forEach((versionCode) => {
-                if (versionCodesToRemove.indexOf(versionCode) === -1) {
+            tl.debug('Current version codes: ' + JSON.stringify(oldTrackVersionCodes));
+
+            if (typeof(versionCodeFilter) === 'string') {
+                tl.debug(`Removing version codes matching the regular expression: ^${versionCodeFilter}$`);
+                const versionCodesToRemove: RegExp = new RegExp(`^${versionCodeFilter}$`);
+
+                oldTrackVersionCodes.forEach((versionCode) => {
+                    if (!versionCode.toString().match(versionCodesToRemove)) {
+                        newTrackVersionCodes.push(versionCode);
+                    }
+                });
+            } else {
+                const versionCodesToRemove = versionCodeFilter;
+                tl.debug('Removing version codes: ' + JSON.stringify(versionCodesToRemove));
+
+                oldTrackVersionCodes.forEach((versionCode) => {
+                    if (versionCodesToRemove.indexOf(versionCode) === -1) {
+                        newTrackVersionCodes.push(versionCode);
+                    }
+                });
+            }
+
+            tl.debug('Version codes to keep: ' + JSON.stringify(newTrackVersionCodes));
+            versionCodes.forEach((versionCode) => {
+                if (newTrackVersionCodes.indexOf(versionCode) === -1) {
                     newTrackVersionCodes.push(versionCode);
                 }
             });
         }
-
-        tl.debug('Version codes to keep: ' + JSON.stringify(newTrackVersionCodes));
-        versionCodes.forEach((versionCode) => {
-            if (newTrackVersionCodes.indexOf(versionCode) === -1) {
-                newTrackVersionCodes.push(versionCode);
-            }
-        });
     }
 
     tl.debug(`New ${track} track version codes: ` + JSON.stringify(newTrackVersionCodes));

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "229",
+        "Minor": "232",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "229",
+    "Minor": "232",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "4.229.0",
+    "version": "4.232.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
***Task name:*** GooglePlayReleaseV4

***Description:*** The `versionCodes` property is not defined when version codes do not exist for the latest completed release.
Appropriate fix implemented. Please hide whitespace to review.

***Documentation changes required:*** No

***Added unit tests:*** No

***Attached related issue:*** N/A

***Checklist:***
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
