### PR TITLE
Changes to upload symbols.zip for aab files

### DIFF
--- a/Tasks/GooglePlayReleaseV4/main.ts
+++ b/Tasks/GooglePlayReleaseV4/main.ts
@@ -138,6 +138,18 @@ async function run(): Promise<void> {
                 const bundle: pub3.Schema$Bundle = await googleutil.addBundle(edits, packageName, bundleFile);
                 tl.debug(`Uploaded ${bundleFile} with the version code ${bundle.versionCode}`);
                 versionCodes.push(bundle.versionCode);
+
+                // Uploading native debug symbols for aab files
+                if (uploadNativeDebugSymbolFiles) {
+                    const nativeDebugSymbolsFilePath: string | null = fileHelper.getSymbolsFile(bundleFile);
+
+                    if (nativeDebugSymbolsFilePath !== null) {
+                        tl.debug(`Uploading ${nativeDebugSymbolsFilePath} for version code ${bundle.versionCode}`);
+                        await googleutil.uploadNativeDeobfuscation(edits, nativeDebugSymbolsFilePath, packageName, bundle.versionCode);
+                    } else {
+                        tl.warning(tl.loc('NotFoundSymbolFiles', bundle.versionCode));
+                    }
+                }
             }
 
             tl.debug(`Uploading ${apkFileList.length} APK(s).`);

--- a/Tasks/GooglePlayReleaseV4/main.ts
+++ b/Tasks/GooglePlayReleaseV4/main.ts
@@ -147,7 +147,7 @@ async function run(): Promise<void> {
                         tl.debug(`Uploading ${nativeDebugSymbolsFilePath} for version code ${bundle.versionCode}`);
                         await googleutil.uploadNativeDeobfuscation(edits, nativeDebugSymbolsFilePath, packageName, bundle.versionCode);
                     } else {
-                        tl.warning(tl.loc('NotFoundSymbolFiles', bundle.versionCode));
+                        tl.warning(tl.loc('NotFoundSymbolsFile', bundle.versionCode));
                     }
                 }
             }

--- a/Tasks/GooglePlayReleaseV4/modules/fileHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/fileHelper.ts
@@ -102,7 +102,7 @@ export function getSymbolsFile(filePath: string): string | null {
     const symbolsFilePath: string = path.join(path.dirname(filePath), 'symbols.zip');
 
     if (fs.existsSync(symbolsFilePath)) {
-        tl.debug(`Found Symbols file for upload in apk directory: ${symbolsFilePath}`);
+        tl.debug(`Found Symbols file for upload in apk/aab directory: ${symbolsFilePath}`);
         return symbolsFilePath;
     }
 

--- a/Tasks/GooglePlayReleaseV4/modules/fileHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/fileHelper.ts
@@ -94,18 +94,18 @@ export function getMappingFile(apkPath: string): string | null {
 }
 
 /**
- * Get `symbols.zip` file from apk directory
- * @param apkPath apk file path
+ * Get `symbols.zip` file from apk/aab directory
+ * @param filePath apk/aab file path
  * @returns path of the `symbols.zip` file if present else null
  */
-export function getSymbolsFile(apkPath: string): string | null {
-    const symbolsFilePath: string = path.join(path.dirname(apkPath), 'symbols.zip');
+export function getSymbolsFile(filePath: string): string | null {
+    const symbolsFilePath: string = path.join(path.dirname(filePath), 'symbols.zip');
 
     if (fs.existsSync(symbolsFilePath)) {
         tl.debug(`Found Symbols file for upload in apk directory: ${symbolsFilePath}`);
         return symbolsFilePath;
     }
 
-    tl.debug(`No Symbols file found for ${apkPath}, skipping upload`);
+    tl.debug(`No Symbols file found for ${filePath}, skipping upload`);
     return null;
 }

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "232",
+        "Minor": "233",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -14,8 +14,8 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "233",
-        "Patch": "0"
+        "Minor": "232",
+        "Patch": "1"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Release $(applicationId) to $(track)",

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -14,8 +14,8 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "233",
-    "Patch": "0"
+    "Minor": "232",
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "232",
+    "Minor": "233",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "4.232.0",
+    "version": "4.232.1",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
**Task name**: Support to upload symbols.zip for aab files.

**Description**: We had made changes to upload symbols.zip in this PR https://github.com/microsoft/google-play-vsts-extension/pull/419 but changes for aab files were missed. Making those changes as part of current PR.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
