### PR TITLE
Remove build config mapping

### DIFF
--- a/Tasks/GooglePlayIncreaseRolloutV2/task.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "235",
+        "Minor": "241",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -124,9 +124,5 @@
         "settableVariables": {
             "allowed": []
         }
-    },
-    "_buildConfigMapping": {
-        "Default": "2.226.0",
-        "Node20-228": "2.235.0"
     }
 }

--- a/Tasks/GooglePlayIncreaseRolloutV2/task.loc.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "235",
+    "Minor": "241",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -124,9 +124,5 @@
     "settableVariables": {
       "allowed": []
     }
-  },
-  "_buildConfigMapping": {
-    "Default": "2.226.0",
-    "Node20-228": "2.235.0"
   }
 }

--- a/Tasks/GooglePlayPromoteV3/task.json
+++ b/Tasks/GooglePlayPromoteV3/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "235",
+        "Minor": "241",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -172,9 +172,5 @@
         "settableVariables": {
             "allowed": []
         }
-    },
-    "_buildConfigMapping": {
-        "Default": "3.226.0",
-        "Node20-228": "3.235.0"
     }
 }

--- a/Tasks/GooglePlayPromoteV3/task.loc.json
+++ b/Tasks/GooglePlayPromoteV3/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "235",
+    "Minor": "241",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -172,9 +172,5 @@
     "settableVariables": {
       "allowed": []
     }
-  },
-  "_buildConfigMapping": {
-    "Default": "3.226.0",
-    "Node20-228": "3.235.0"
   }
 }

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "240",
+        "Minor": "241",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -393,9 +393,5 @@
         "settableVariables": {
             "allowed": []
         }
-    },
-    "_buildConfigMapping": {
-        "Default": "4.232.1",
-        "Node20-228": "4.235.0"
     }
 }

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "240",
+    "Minor": "241",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -393,9 +393,5 @@
     "settableVariables": {
       "allowed": []
     }
-  },
-  "_buildConfigMapping": {
-    "Default": "4.232.1",
-    "Node20-228": "4.235.0"
   }
 }

--- a/Tasks/GooglePlayStatusUpdateV2/task.json
+++ b/Tasks/GooglePlayStatusUpdateV2/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "235",
+        "Minor": "241",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -137,9 +137,5 @@
         "settableVariables": {
             "allowed": []
         }
-    },
-    "_buildConfigMapping": {
-        "Default": "2.226.0",
-        "Node20-228": "2.235.0"
     }
 }

--- a/Tasks/GooglePlayStatusUpdateV2/task.loc.json
+++ b/Tasks/GooglePlayStatusUpdateV2/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "235",
+    "Minor": "241",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -137,9 +137,5 @@
     "settableVariables": {
       "allowed": []
     }
-  },
-  "_buildConfigMapping": {
-    "Default": "2.226.0",
-    "Node20-228": "2.235.0"
   }
 }

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "4.240.0",
+    "version": "4.241.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
***Description:*** Remove `_buildConfigMapping` from `task.json` and `task.loc.json` for all tasks in the extension.

***Documentation changes required:*** No

***Added unit tests:*** No

***Checklist:***
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
