### PR TITLE
chore: switch release pipeline to GH specific SC

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ extends:
         - task: EsrpCodeSigning@5
           displayName: ESRP CodeSigning
           inputs:
-            ConnectedServiceName: '$(Control.EsrpServiceConnectionName)'
+            ConnectedServiceName: '$(Control.EsrpServiceConnectionName.GH)'
             AppRegistrationClientId: '$(Control.AppRegistrationClientId)'
             AppRegistrationTenantId: '$(Control.AppRegistrationTenantId)'
             AuthAKVName: '$(Control.AuthAKVName)'


### PR DESCRIPTION
The change is required to tighten security of release pipelines for GitHub repos.
New [Service Connection](https://dev.azure.com/mseng/AzureDevOps/_settings/adminservices?resourceId=33c3e760-0a0f-4096-8a99-79e54de8fc88) was created/cloned from existing one with additional checks.
The reference to new SC was also added to the [Library](https://dev.azure.com/mseng/AzureDevOps/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=582&path=EPS.ESRPSigningProdAME) under new var name.

[ADO WorkItem 2319065](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2319065)