### PR TITLE
Updating all google play extension tasks with node24

### DIFF
--- a/Tasks/GooglePlayIncreaseRolloutV2/google-play-increase-rollout.ts
+++ b/Tasks/GooglePlayIncreaseRolloutV2/google-play-increase-rollout.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as googleutil from './googleutil';
 
@@ -13,7 +14,7 @@ async function run() {
             if (!serviceAccountKeyFile) {
                 throw new Error(tl.loc('JsonKeyFileNotFound'));
             }
-            const stats: tl.FsStats = tl.stats(serviceAccountKeyFile);
+            const stats: fs.Stats = tl.stats(serviceAccountKeyFile);
             if (stats && stats.isFile()) {
                 key = require(serviceAccountKeyFile);
             } else {

--- a/Tasks/GooglePlayIncreaseRolloutV2/package-lock.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/package-lock.json
@@ -10,13 +10,48 @@
       "license": "ISC",
       "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^20.11.6",
-        "azure-pipelines-task-lib": "^4.13.0",
+        "@types/node": "^24.10.0",
+        "azure-pipelines-task-lib": "^5.2.4",
         "google-auth-library": "^7.14.1",
         "googleapis": "^67.1.0"
       },
       "devDependencies": {
-        "typescript": "5.1.6"
+        "typescript": "5.7.2"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@types/mocha": {
@@ -26,12 +61,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.16.1.tgz",
-      "integrity": "sha1-C0SxUnHQ4hkcpo+vH75Qbgau1zI=",
+      "version": "24.10.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha1-GutRQuSpKVdInKwSsH+cf+JgV9A=",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/abort-controller": {
@@ -77,9 +112,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.16.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.16.0.tgz",
-      "integrity": "sha1-/6rKihraJAeA7w9BG9fGsru2UgA=",
+      "version": "5.2.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.5.tgz",
+      "integrity": "sha1-Rxt2sbMsUDb8xLAq0CE4p1Sh070=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -87,7 +122,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
+        "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
       }
     },
@@ -136,6 +171,18 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -166,6 +213,20 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.6",
@@ -240,17 +301,77 @@
         "node": ">=6"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-text-encoding": {
       "version": "1.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
       "integrity": "sha1-CqJff2OCIuM5bXK/k2r88dQtaGc=",
       "license": "Apache-2.0"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -271,12 +392,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -335,37 +450,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "is-glob": "^4.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">= 6"
       }
     },
     "node_modules/google-auth-library": {
@@ -530,45 +636,43 @@
         "node": ">= 6"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "license": "ISC"
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha1-pzY6Jb7pQv76sN4Tv2qjcsgtzDc=",
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "is-extglob": "^2.1.1"
       },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-stream": {
@@ -582,6 +686,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "license": "ISC"
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -625,6 +735,34 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
@@ -644,6 +782,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -705,6 +852,18 @@
         "sanitize-filename": "^1.6.3"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.2.tgz",
@@ -717,29 +876,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "license": "ISC",
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "license": "MIT",
       "dependencies": {
-        "wrappy": "1"
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/q": {
       "version": "1.5.1",
@@ -767,32 +938,57 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha1-tsh6nyqgbfq1Lj1wrIzeMh+lpI0=",
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -850,21 +1046,38 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "license": "BSD-3-Clause",
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+      "license": "MIT",
       "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
+        "shebang-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
+      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "fast-glob": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/side-channel": {
@@ -885,16 +1098,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "license": "ISC"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tr46": {
@@ -913,9 +1141,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha1-AvisICttrSwN1eCRN0W0ejeZgnQ=",
+      "version": "5.7.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha1-MWnPjEyKgozeU7qeyz0rHV3We+Y=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -927,9 +1155,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha1-NREcnRQ3q4OnzcCrri8m2I7aCgI=",
+      "version": "7.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY=",
       "license": "MIT"
     },
     "node_modules/url-template": {
@@ -970,11 +1198,20 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "license": "ISC"
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/Tasks/GooglePlayIncreaseRolloutV2/package.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/package.json
@@ -10,12 +10,12 @@
   "license": "ISC",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^20.11.6",
-    "azure-pipelines-task-lib": "^4.13.0",
+    "@types/node": "^24.10.0",
+    "azure-pipelines-task-lib": "^5.2.4",
     "google-auth-library": "^7.14.1",
     "googleapis": "^67.1.0"
   },
   "devDependencies": {
-    "typescript": "5.1.6"
+    "typescript": "5.7.2"
   }
 }

--- a/Tasks/GooglePlayIncreaseRolloutV2/task.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "244",
+        "Minor": "269",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -95,6 +95,10 @@
             "argumentFormat": ""
         },
         "Node20_1": {
+            "target": "google-play-increase-rollout.js",
+            "argumentFormat": ""
+        },
+        "Node24": {
             "target": "google-play-increase-rollout.js",
             "argumentFormat": ""
         },

--- a/Tasks/GooglePlayIncreaseRolloutV2/task.loc.json
+++ b/Tasks/GooglePlayIncreaseRolloutV2/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "244",
+    "Minor": "269",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -95,6 +95,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "google-play-increase-rollout.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "google-play-increase-rollout.js",
       "argumentFormat": ""
     },

--- a/Tasks/GooglePlayPromoteV3/google-play-promote.ts
+++ b/Tasks/GooglePlayPromoteV3/google-play-promote.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as googleutil from './googleutil';
 
@@ -12,7 +13,7 @@ async function run() {
             if (!serviceAccountKeyFile) {
                 throw new Error(tl.loc('JsonKeyFileNotFound'));
             }
-            const stats: tl.FsStats = tl.stats(serviceAccountKeyFile);
+            const stats: fs.Stats = tl.stats(serviceAccountKeyFile);
             if (stats && stats.isFile()) {
                 key = require(serviceAccountKeyFile);
             } else {

--- a/Tasks/GooglePlayPromoteV3/package-lock.json
+++ b/Tasks/GooglePlayPromoteV3/package-lock.json
@@ -10,13 +10,48 @@
       "license": "ISC",
       "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^20.11.6",
-        "azure-pipelines-task-lib": "^4.13.0",
+        "@types/node": "^24.10.0",
+        "azure-pipelines-task-lib": "^5.2.4",
         "google-auth-library": "^7.14.1",
         "googleapis": "^67.1.0"
       },
       "devDependencies": {
-        "typescript": "5.1.6"
+        "typescript": "5.7.2"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@types/mocha": {
@@ -26,12 +61,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.16.1.tgz",
-      "integrity": "sha1-C0SxUnHQ4hkcpo+vH75Qbgau1zI=",
+      "version": "24.10.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha1-GutRQuSpKVdInKwSsH+cf+JgV9A=",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/abort-controller": {
@@ -77,9 +112,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.16.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.16.0.tgz",
-      "integrity": "sha1-/6rKihraJAeA7w9BG9fGsru2UgA=",
+      "version": "5.2.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.5.tgz",
+      "integrity": "sha1-Rxt2sbMsUDb8xLAq0CE4p1Sh070=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -87,7 +122,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
+        "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
       }
     },
@@ -136,6 +171,18 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -166,6 +213,20 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.6",
@@ -240,17 +301,77 @@
         "node": ">=6"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-text-encoding": {
       "version": "1.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
       "integrity": "sha1-CqJff2OCIuM5bXK/k2r88dQtaGc=",
       "license": "Apache-2.0"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -271,12 +392,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -335,37 +450,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "is-glob": "^4.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">= 6"
       }
     },
     "node_modules/google-auth-library": {
@@ -530,45 +636,43 @@
         "node": ">= 6"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "license": "ISC"
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha1-pzY6Jb7pQv76sN4Tv2qjcsgtzDc=",
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "is-extglob": "^2.1.1"
       },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-stream": {
@@ -582,6 +686,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "license": "ISC"
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -625,6 +735,34 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
@@ -644,6 +782,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -705,6 +852,18 @@
         "sanitize-filename": "^1.6.3"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.2.tgz",
@@ -717,29 +876,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "license": "ISC",
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "license": "MIT",
       "dependencies": {
-        "wrappy": "1"
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/q": {
       "version": "1.5.1",
@@ -767,32 +938,57 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha1-tsh6nyqgbfq1Lj1wrIzeMh+lpI0=",
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -850,21 +1046,38 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "license": "BSD-3-Clause",
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+      "license": "MIT",
       "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
+        "shebang-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
+      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "fast-glob": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/side-channel": {
@@ -885,16 +1098,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "license": "ISC"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tr46": {
@@ -913,9 +1141,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha1-AvisICttrSwN1eCRN0W0ejeZgnQ=",
+      "version": "5.7.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha1-MWnPjEyKgozeU7qeyz0rHV3We+Y=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -927,9 +1155,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha1-NREcnRQ3q4OnzcCrri8m2I7aCgI=",
+      "version": "7.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY=",
       "license": "MIT"
     },
     "node_modules/url-template": {
@@ -970,11 +1198,20 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "license": "ISC"
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/Tasks/GooglePlayPromoteV3/package.json
+++ b/Tasks/GooglePlayPromoteV3/package.json
@@ -10,12 +10,12 @@
   "license": "ISC",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^20.11.6",
-    "azure-pipelines-task-lib": "^4.13.0",
+    "@types/node": "^24.10.0",
+    "azure-pipelines-task-lib": "^5.2.4",
     "google-auth-library": "^7.14.1",
     "googleapis": "^67.1.0"
   },
   "devDependencies": {
-    "typescript": "5.1.6"
+    "typescript": "5.7.2"
   }
 }

--- a/Tasks/GooglePlayPromoteV3/task.json
+++ b/Tasks/GooglePlayPromoteV3/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "3",
-        "Minor": "244",
+        "Minor": "269",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -139,6 +139,10 @@
             "argumentFormat": ""
         },
         "Node20_1": {
+            "target": "google-play-promote.js",
+            "argumentFormat": ""
+        },
+        "Node24": {
             "target": "google-play-promote.js",
             "argumentFormat": ""
         },

--- a/Tasks/GooglePlayPromoteV3/task.loc.json
+++ b/Tasks/GooglePlayPromoteV3/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "3",
-    "Minor": "244",
+    "Minor": "269",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -139,6 +139,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "google-play-promote.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "google-play-promote.js",
       "argumentFormat": ""
     },

--- a/Tasks/GooglePlayReleaseV4/modules/inputsHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/inputsHelper.ts
@@ -1,5 +1,5 @@
 import * as tl from 'azure-pipelines-task-lib/task';
-
+import * as fs from 'fs';
 import * as googleutil from './googleutil';
 import * as fileHelper from './fileHelper';
 
@@ -13,7 +13,7 @@ export function getClientKey(): googleutil.ClientKey {
     if (authType === 'JsonFile') {
         const serviceAccountKeyFile: string = tl.getPathInput('serviceAccountKey', true, true);
 
-        const stats: tl.FsStats = tl.stats(serviceAccountKeyFile);
+        const stats: fs.Stats = tl.stats(serviceAccountKeyFile);
         if (stats && stats.isFile()) {
             key = require(serviceAccountKeyFile);
         } else {

--- a/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
+++ b/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts
@@ -13,7 +13,7 @@ import { androidpublisher_v3 as pub3 } from 'googleapis';
  * @returns {pub3.Schema$LocalizedText[]} `[{ language: 'en-US|fr-FR|it-IT|...', text: 'Localized_Release_Notes' }, ...]`
  */
 export async function getCommonReleaseNotes(languageCode: string, changelogFile: string, releaseNotesContainLanguageTags: boolean): Promise<pub3.Schema$LocalizedText[]> {
-    const stats: tl.FsStats = tl.stats(changelogFile);
+    const stats: fs.Stats = tl.stats(changelogFile);
     const releaseNotes: pub3.Schema$LocalizedText[] = [];
 
     if (stats && stats.isFile()) {
@@ -129,10 +129,10 @@ async function appendChangelogToReleaseNotes(
 /**
  * Filters the directory contents to find files or directories
  * @param {string} directory the directory to search
- * @param {(stats: tl.FsStats) => boolean} filter callback on every item in the directory, return true to keep the results
+ * @param {(stats: fs.Stats) => boolean} filter callback on every item in the directory, return true to keep the results
  * @returns the filtered contents of the directory
  */
-function filterDirectoryContents(directory: string, filter: (stats: tl.FsStats) => boolean): string[] {
+function filterDirectoryContents(directory: string, filter: (stats: fs.Stats) => boolean): string[] {
     return fs.readdirSync(directory).filter(subPath => {
         try {
             const fullPath: string = path.join(directory, subPath);
@@ -404,7 +404,7 @@ function getImageList(directory: string): { [key: string]: string[] } {
                 for (let acceptedExtension of acceptedExtensions) {
                     let fullPathToFileToCheck: string = path.join(imageDirectory, imageType + acceptedExtension);
                     try {
-                        let imageStat: tl.FsStats = tl.stats(fullPathToFileToCheck);
+                        let imageStat: fs.Stats = tl.stats(fullPathToFileToCheck);
                         if (imageStat) {
                             shouldAttemptUpload = imageStat.isFile();
                             if (shouldAttemptUpload) {

--- a/Tasks/GooglePlayReleaseV4/package-lock.json
+++ b/Tasks/GooglePlayReleaseV4/package-lock.json
@@ -10,14 +10,14 @@
       "dependencies": {
         "@types/jsdom": "^21.1.7",
         "@types/mocha": "^9.0.0",
-        "@types/node": "^20.11.6",
-        "azure-pipelines-task-lib": "^4.13.0",
+        "@types/node": "^24.10.0",
+        "azure-pipelines-task-lib": "^5.2.4",
         "glob": "^7.1.7",
         "googleapis": "^90.0.0",
         "jsdom": "26.1.0"
       },
       "devDependencies": {
-        "typescript": "5.1.6"
+        "typescript": "5.7.2"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -117,6 +117,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -138,8 +139,44 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@types/jsdom": {
@@ -159,12 +196,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.16.1.tgz",
-      "integrity": "sha1-C0SxUnHQ4hkcpo+vH75Qbgau1zI=",
+      "version": "24.10.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha1-GutRQuSpKVdInKwSsH+cf+JgV9A=",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -216,9 +253,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.16.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.16.0.tgz",
-      "integrity": "sha1-/6rKihraJAeA7w9BG9fGsru2UgA=",
+      "version": "5.2.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.5.tgz",
+      "integrity": "sha1-Rxt2sbMsUDb8xLAq0CE4p1Sh070=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -226,7 +263,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
+        "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
       }
     },
@@ -275,6 +312,18 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -305,6 +354,20 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -419,17 +482,77 @@
         "node": ">=6"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-text-encoding": {
       "version": "1.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
       "integrity": "sha1-CqJff2OCIuM5bXK/k2r88dQtaGc=",
       "license": "Apache-2.0"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -514,6 +637,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
@@ -533,6 +668,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -740,6 +887,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -768,28 +924,34 @@
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "license": "ISC"
     },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha1-pzY6Jb7pQv76sN4Tv2qjcsgtzDc=",
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "is-extglob": "^2.1.1"
       },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -809,6 +971,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "license": "ISC"
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
@@ -910,6 +1078,34 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
@@ -929,6 +1125,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -1012,6 +1217,18 @@
         "sanitize-filename": "^1.6.3"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.21",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nwsapi/-/nwsapi-2.2.21.tgz",
@@ -1038,6 +1255,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse5/-/parse5-7.3.0.tgz",
@@ -1058,11 +1290,26 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -1098,38 +1345,63 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
-    "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha1-tsh6nyqgbfq1Lj1wrIzeMh+lpI0=",
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
       "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha1-MCHRtDUvvzthSq7tC8DVc5q+C8I="
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1202,21 +1474,38 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "license": "BSD-3-Clause",
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+      "license": "MIT",
       "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
+        "shebang-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
+      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "fast-glob": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/side-channel": {
@@ -1237,16 +1526,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "license": "ISC"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=6"
       }
     },
     "node_modules/symbol-tree": {
@@ -1270,6 +1562,18 @@
       "version": "6.1.86",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha1-qT5u2dUFy1TFQs5D/rFMc5EyZdg="
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
@@ -1303,9 +1607,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha1-AvisICttrSwN1eCRN0W0ejeZgnQ=",
+      "version": "5.7.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha1-MWnPjEyKgozeU7qeyz0rHV3We+Y=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1317,9 +1621,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha1-NREcnRQ3q4OnzcCrri8m2I7aCgI=",
+      "version": "7.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY=",
       "license": "MIT"
     },
     "node_modules/url-template": {
@@ -1392,6 +1696,21 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wrappy": {

--- a/Tasks/GooglePlayReleaseV4/package.json
+++ b/Tasks/GooglePlayReleaseV4/package.json
@@ -4,13 +4,13 @@
   "dependencies": {
     "@types/jsdom": "^21.1.7",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^20.11.6",
-    "azure-pipelines-task-lib": "^4.13.0",
+    "@types/node": "^24.10.0",
+    "azure-pipelines-task-lib": "^5.2.4",
     "glob": "^7.1.7",
     "googleapis": "^90.0.0",
     "jsdom": "26.1.0"
   },
   "devDependencies": {
-    "typescript": "5.1.6"
+    "typescript": "5.7.2"
   }
 }

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "261",
+        "Minor": "269",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -348,6 +348,10 @@
             "argumentFormat": ""
         },
         "Node20_1": {
+            "target": "main.js",
+            "argumentFormat": ""
+        },
+        "Node24": {
             "target": "main.js",
             "argumentFormat": ""
         }

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "261",
+    "Minor": "269",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -348,6 +348,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "main.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "main.js",
       "argumentFormat": ""
     }

--- a/Tasks/GooglePlayStatusUpdateV2/google-play-status-update.ts
+++ b/Tasks/GooglePlayStatusUpdateV2/google-play-status-update.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as googleutil from './googleutil';
 import { androidpublisher_v3 } from 'googleapis';
@@ -16,7 +17,7 @@ async function run() {
             if (!serviceAccountKeyFile) {
                 throw new Error(tl.loc('JsonKeyFileNotFound'));
             }
-            const stats: tl.FsStats = tl.stats(serviceAccountKeyFile);
+            const stats: fs.Stats = tl.stats(serviceAccountKeyFile);
             if (stats && stats.isFile()) {
                 key = require(serviceAccountKeyFile);
             } else {

--- a/Tasks/GooglePlayStatusUpdateV2/package-lock.json
+++ b/Tasks/GooglePlayStatusUpdateV2/package-lock.json
@@ -10,13 +10,48 @@
             "license": "ISC",
             "dependencies": {
                 "@types/mocha": "^5.2.7",
-                "@types/node": "^20.11.6",
-                "azure-pipelines-task-lib": "^4.13.0",
+                "@types/node": "^24.10.0",
+                "azure-pipelines-task-lib": "^5.2.4",
                 "google-auth-library": "^7.14.1",
                 "googleapis": "^67.1.0"
             },
             "devDependencies": {
-                "typescript": "5.1.6"
+                "typescript": "5.7.2"
+            }
+        },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/@types/mocha": {
@@ -26,12 +61,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.16.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.16.1.tgz",
-            "integrity": "sha1-C0SxUnHQ4hkcpo+vH75Qbgau1zI=",
+            "version": "24.10.9",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.9.tgz",
+            "integrity": "sha1-GutRQuSpKVdInKwSsH+cf+JgV9A=",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~7.16.0"
             }
         },
         "node_modules/abort-controller": {
@@ -77,9 +112,9 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "4.16.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.16.0.tgz",
-            "integrity": "sha1-/6rKihraJAeA7w9BG9fGsru2UgA=",
+            "version": "5.2.5",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.5.tgz",
+            "integrity": "sha1-Rxt2sbMsUDb8xLAq0CE4p1Sh070=",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
@@ -87,7 +122,7 @@
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
             }
         },
@@ -136,6 +171,18 @@
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -166,6 +213,20 @@
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.6",
@@ -240,17 +301,77 @@
                 "node": ">=6"
             }
         },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend/-/extend-3.0.2.tgz",
             "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
             "license": "MIT"
         },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
         "node_modules/fast-text-encoding": {
             "version": "1.0.6",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
             "integrity": "sha1-CqJff2OCIuM5bXK/k2r88dQtaGc=",
             "license": "Apache-2.0"
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/follow-redirects": {
             "version": "1.15.6",
@@ -271,12 +392,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -335,37 +450,28 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+            "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">=10"
             },
             "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "is-glob": "^4.0.1"
             },
             "engines": {
-                "node": "*"
+                "node": ">= 6"
             }
         },
         "node_modules/google-auth-library": {
@@ -530,45 +636,43 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
             }
         },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.10"
+                "node": ">=0.10.0"
             }
         },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha1-pzY6Jb7pQv76sN4Tv2qjcsgtzDc=",
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "is-extglob": "^2.1.1"
             },
             "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
             }
         },
         "node_modules/is-stream": {
@@ -582,6 +686,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "license": "ISC"
         },
         "node_modules/json-bigint": {
             "version": "1.0.0",
@@ -625,6 +735,34 @@
                 "node": ">=10"
             }
         },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
@@ -644,6 +782,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -705,6 +852,18 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.2",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.2.tgz",
@@ -717,29 +876,41 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "license": "ISC",
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+            "license": "MIT",
             "dependencies": {
-                "wrappy": "1"
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
             "license": "MIT",
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-            "license": "MIT"
+        "node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -767,32 +938,57 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.10"
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
             }
         },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha1-tsh6nyqgbfq1Lj1wrIzeMh+lpI0=",
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/safe-buffer": {
@@ -850,21 +1046,38 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-            "license": "BSD-3-Clause",
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+            "license": "MIT",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "shebang-regex": "^3.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
@@ -885,16 +1098,31 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.4"
+                "node": ">=6"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/tr46": {
@@ -913,9 +1141,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha1-AvisICttrSwN1eCRN0W0ejeZgnQ=",
+            "version": "5.7.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.7.2.tgz",
+            "integrity": "sha1-MWnPjEyKgozeU7qeyz0rHV3We+Y=",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -927,9 +1155,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha1-NREcnRQ3q4OnzcCrri8m2I7aCgI=",
+            "version": "7.16.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY=",
             "license": "MIT"
         },
         "node_modules/url-template": {
@@ -970,11 +1198,20 @@
                 "webidl-conversions": "^3.0.0"
             }
         },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "license": "ISC"
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
+            "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/yallist": {
             "version": "4.0.0",

--- a/Tasks/GooglePlayStatusUpdateV2/package.json
+++ b/Tasks/GooglePlayStatusUpdateV2/package.json
@@ -10,12 +10,12 @@
     "license": "ISC",
     "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^20.11.6",
-        "azure-pipelines-task-lib": "^4.13.0",
+        "@types/node": "^24.10.0",
+        "azure-pipelines-task-lib": "^5.2.4",
         "google-auth-library": "^7.14.1",
         "googleapis": "^67.1.0"
     },
     "devDependencies": {
-        "typescript": "5.1.6"
+        "typescript": "5.7.2"
     }
 }

--- a/Tasks/GooglePlayStatusUpdateV2/task.json
+++ b/Tasks/GooglePlayStatusUpdateV2/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "244",
+        "Minor": "269",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -110,6 +110,10 @@
             "argumentFormat": ""
         },
         "Node20_1": {
+            "target": "google-play-status-update.js",
+            "argumentFormat": ""
+        },
+        "Node24": {
             "target": "google-play-status-update.js",
             "argumentFormat": ""
         }

--- a/Tasks/GooglePlayStatusUpdateV2/task.loc.json
+++ b/Tasks/GooglePlayStatusUpdateV2/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": "2",
-    "Minor": "244",
+    "Minor": "269",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -110,6 +110,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "google-play-status-update.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "google-play-status-update.js",
       "argumentFormat": ""
     }

--- a/dev-dependencies-constants.js
+++ b/dev-dependencies-constants.js
@@ -6,7 +6,7 @@
 /** Target mocha version for running tests */
 exports.MOCHA_TARGET_VERSION = '10.7.3';
 /** Current typescript version */
-exports.TSC_CURRENT_VERSION = '5.1.6';
+exports.TSC_CURRENT_VERSION = '5.7.2';
 /** Minimum supported node version */
 exports.NODE_MIN_VERSION = '10.0.0';
 /** Minimum supported npm version */

--- a/make-util.js
+++ b/make-util.js
@@ -1065,6 +1065,9 @@ exports.storeNonAggregatedZip = storeNonAggregatedZip;
 
 var installNodeAsync = async function (nodeVersion) {
     switch (nodeVersion || '') {
+        case '24':
+            nodeVersion = 'v24.10.0';
+            break;
         case '20':
             nodeVersion = 'v20.14.0';
             break;
@@ -1139,7 +1142,9 @@ var getTaskNodeVersion = function(buildPath, taskName) {
     var execution = taskJson['execution'] || taskJson['prejobexecution'];
     let nodeVersion = 0;
     for (var key of Object.keys(execution)) {
-        if (key.toLowerCase() == 'node20_1') {
+        if (key.toLowerCase() == 'node24') {
+            nodeVersion = Math.max(24, nodeVersion);
+        } else if (key.toLowerCase() == 'node20_1') {
             nodeVersion = Math.max(20, nodeVersion);
         } else if (key.toLowerCase() == 'node16') {
             nodeVersion = Math.max(16, nodeVersion);

--- a/make.js
+++ b/make.js
@@ -65,7 +65,7 @@ if (semver.lt(process.versions.node,  NODE_MIN_VERSION)) {
     fail(`requires node >= ${NODE_MIN_VERSION}. installed: ${process.versions.node}`);
 }
 
-var supportedNodeTargets = ["Node", "Node10", "Node16", "Node20_1"];
+var supportedNodeTargets = ["Node", "Node10", "Node16", "Node20_1", "Node24"];
 
 // add node modules .bin to the path so we can dictate version of tsc etc...
 var binPath = path.join(__dirname, 'node_modules', '.bin');

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "sinon": "7.3.2",
         "tfx-cli": "^0.17.0",
         "tslint": "^5.20.1",
-        "typescript": "5.1.6",
+        "typescript": "5.7.2",
         "validator": "^13.7.0",
         "yargs": "^17.5.1"
       }
@@ -3654,10 +3654,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha1-AvisICttrSwN1eCRN0W0ejeZgnQ=",
+      "version": "5.7.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha1-MWnPjEyKgozeU7qeyz0rHV3We+Y=",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sinon": "7.3.2",
     "tfx-cli": "^0.17.0",
     "tslint": "^5.20.1",
-    "typescript": "5.1.6",
+    "typescript": "5.7.2",
     "validator": "^13.7.0",
     "yargs": "^17.5.1"
   }

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "4.261.1",
+    "version": "4.269.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
**Task name**: 
        
"GooglePlayReleaseV4",
        "GooglePlayPromoteV3",
        "GooglePlayIncreaseRolloutV2",
        "GooglePlayStatusUpdateV2"<Name of changed or new pipeline task>

**Description**: This PR upgrades all Google Play extension tasks to support Node.js 24 <Describe your changes here>
Updated the dev dependencies to the newer type script version (5.7.2), updated the task-lib to ^5.2.4, @types/node to 24.10.0. Added node24 handlers to all tasks and updated their versions.  FsStats is removed from task-lib so changed it to fs.Stats. 

**Documentation changes required:** (Y/N) No <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) No <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
