### PR TITLE
Vulnerability fixes for the GooglePlayReleaseV4 task

### DIFF
--- a/Tasks/GooglePlayReleaseV4/package-lock.json
+++ b/Tasks/GooglePlayReleaseV4/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/jsdom": "^21.1.7",
         "@types/mocha": "^9.0.0",
-        "@types/node": "24.10.0",
+        "@types/node": "^24.10.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "glob": "^7.1.7",
         "googleapis": "^90.0.0",

--- a/Tasks/GooglePlayReleaseV4/package-lock.json
+++ b/Tasks/GooglePlayReleaseV4/package-lock.json
@@ -10,37 +10,76 @@
       "dependencies": {
         "@types/jsdom": "^21.1.7",
         "@types/mocha": "^9.0.0",
-        "@types/node": "^24.10.0",
+        "@types/node": "24.10.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "glob": "^7.1.7",
         "googleapis": "^90.0.0",
-        "jsdom": "26.1.0"
+        "jsdom": "27.4.0"
       },
       "devDependencies": {
         "typescript": "5.7.2"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha1-vVM30pD7i+KsGDkfNzhrxTd4sLw=",
+      "license": "MIT"
+    },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha1-zEL1uFxZP3nx+k8l0rmzIeYdF5Q=",
+      "version": "4.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha1-ESPhizZS/4j73ZDWHy4uRN2Loo8=",
+      "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk="
+      "version": "11.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha1-89qjVAhHuXN+vAJJnds2dl5U20o=",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha1-ObIJk2crEG982aOppGUhLofgv9E=",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha1-89qjVAhHuXN+vAJJnds2dl5U20o=",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha1-rVVJMi3+nRU9S03W9/8q4jSwbiQ=",
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-      "integrity": "sha1-glksmnwrg8KT2RYYlOKmRx/rl7g=",
+      "version": "6.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha1-gsWf0wZJzwtNPIIWBIl0hmbmVQs=",
       "funding": [
         {
           "type": "github",
@@ -51,14 +90,15 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha1-hHP2Pi/NbkWYON1BJAHVlI8iTGU=",
+      "version": "3.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha1-sw4GHKnyl8yys7Ayv+4y/aArGyc=",
       "funding": [
         {
           "type": "github",
@@ -69,18 +109,19 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.0.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
-      "integrity": "sha1-efxohk3UPDtngtKzgovA+p0IXBA=",
+      "version": "4.1.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+      "integrity": "sha1-VMFWcDpAcqI7D15TkVzjR59NKew=",
       "funding": [
         {
           "type": "github",
@@ -91,22 +132,23 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha1-V1U3Cpopq67FUVtDyLPyz5wuMHY=",
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha1-4cZdwJN4tC8moRH8p/cHX8LCYWQ=",
       "funding": [
         {
           "type": "github",
@@ -117,17 +159,43 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
+      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha1-uOJuD+Jemm7GB9BFRwzEbS9icx4=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha1-Mz/tq8P9Go5dAQABNzHPGeaoxdM=",
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha1-eYozlQ0RImoOu2rK+mD1WUQkln8=",
       "funding": [
         {
           "type": "github",
@@ -138,8 +206,27 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
+      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha1-sTvEZMoWLBer8IN/s6Ea6reeRdE=",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -181,6 +268,7 @@
       "version": "21.1.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/jsdom/-/jsdom-21.1.7.tgz",
       "integrity": "sha1-ntywngsHzodueDOSLTJ0FJyJjPo=",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
@@ -194,9 +282,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.9.tgz",
-      "integrity": "sha1-GutRQuSpKVdInKwSsH+cf+JgV9A=",
+      "version": "24.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha1-a3kIaw38VOd1o0uoEU3MTgIh8x8=",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -221,9 +309,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.15.tgz",
-      "integrity": "sha1-wsmz1POxyRHnKyOU6E/ZG8yB4I4=",
+      "version": "0.5.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -251,9 +339,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.2.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
+      "integrity": "sha1-4WT2NUK4K1n7dRDmeuRuTTC/J94=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -291,19 +379,28 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha1-b4vPPId8TZIg3fSbm7aTDIj4d9I=",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha1-t8QkIlnACJA7E3B5g7X0u9Me2gw=",
+      "version": "9.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha1-dZxard8v/cTxVPe0k+HIdw+IxNc=",
       "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha1-03h1wB3J7/mI3UnREqV8tntU7+Y=",
+      "version": "1.1.15",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -377,37 +474,72 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "4.6.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha1-6hgAcCTjFn9PEFMV8+wtmCv0jtk=",
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha1-hsrHARVhJysw5rHgQrps4EeqdRg=",
+      "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha1-IgLlarzs+XroHdd4P8irxfBEMF0=",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha1-89qjVAhHuXN+vAJJnds2dl5U20o=",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha1-L3aQa84YJEKf/stpIPRaCzDwDd4=",
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha1-tEjIY3mXq+NJeMm/2z0Kd3hUAYQ=",
+      "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha1-2CMoldvVJ86u5079QWIAj7ioz0g=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha1-KrLDj7r/6/iqlf3+bYhDjHoTxSs=",
+      "version": "4.4.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -421,7 +553,8 @@
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha1-5kmkPjq5U6chkv9Zg4ZeUJ837Zo="
+      "integrity": "sha1-5kmkPjq5U6chkv9Zg4ZeUJ837Zo=",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -450,6 +583,7 @@
       "version": "6.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/entities/-/entities-6.0.1.tgz",
       "integrity": "sha1-wow0pDN5yn9h0HQTCy9fcCCjBpQ=",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -476,9 +610,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -569,9 +703,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
+      "version": "1.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "funding": [
         {
           "type": "individual",
@@ -828,9 +962,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -840,20 +974,22 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha1-aW31KafP2CRGNp3FGT5ZCjc1tEg=",
+      "version": "6.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha1-+Nk5Czs0i1DU9hwW3S71wFmAqII=",
+      "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -866,6 +1002,7 @@
       "version": "7.1.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -890,17 +1027,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/inflight": {
@@ -975,33 +1101,34 @@
       "license": "ISC"
     },
     "node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha1-q18cHK/AS9h4clSQl06l6L8McrM=",
+      "version": "27.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha1-w2ry5D4Sgafou48lUIZDXRd4AfI=",
+      "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
+        "tough-cookie": "^6.0.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
+        "webidl-conversions": "^8.0.0",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -1016,20 +1143,46 @@
       "version": "7.1.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha1-wd9f42AkKXR/ojPQ3SbxQvDOR0M=",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/jsdom/node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha1-9DvNLNaD7+CEB1Mz6c4Np9Btox4=",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/json-bigint": {
@@ -1082,6 +1235,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha1-43ucUIgLdTZsTUCsY9m7ys22Hw4=",
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -1154,9 +1313,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -1234,11 +1393,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/nwsapi": {
-      "version": "2.2.21",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nwsapi/-/nwsapi-2.2.21.tgz",
-      "integrity": "sha1-jfd5cHk1Ct2iCJENjDP8TC11IMM="
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1279,6 +1433,7 @@
       "version": "7.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha1-1+Ik+nI5nHoXUJn0X8KtAksF7AU=",
+      "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -1320,6 +1475,7 @@
       "version": "2.3.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1336,9 +1492,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha1-24/V0bHS1rWzOtr4dCmAXxkJ57M=",
+      "version": "6.15.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha1-/VVCbXEEA93MxF4PnqsW23cn7Ok=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1370,6 +1526,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
@@ -1379,11 +1544,6 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha1-MCHRtDUvvzthSq7tC8DVc5q+C8I="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -1428,15 +1588,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
-    },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
@@ -1446,6 +1601,7 @@
       "version": "6.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha1-/ltKR2jfTxSiAbG6amXB89mYjMU=",
+      "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -1497,14 +1653,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1516,13 +1672,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1574,6 +1730,15 @@
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -1590,20 +1755,22 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha1-CH4FVbMblyXuSMp+d+3FYRXNgvc=",
+      "version": "7.4.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tldts/-/tldts-7.4.4.tgz",
+      "integrity": "sha1-NDGRNIq7/4ARhzKhqE6Q/PlbKd8=",
+      "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.4"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha1-qT5u2dUFy1TFQs5D/rFMc5EyZdg="
+      "version": "7.4.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tldts-core/-/tldts-core-7.4.4.tgz",
+      "integrity": "sha1-oG3iKMcKM04m0Vl696gjduhYi84=",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1618,25 +1785,27 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha1-Ztd0tKHZ4S3HUIlyWvOsdewxvtc=",
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha1-pJX4M4NmCe2YPBm8ZWOc+861THY=",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha1-lq6GfN24/bZKScwwWajUKLzyOMo=",
+      "version": "6.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha1-9aGuVGoK2zKid6InjQ0X+i+Qk+Y=",
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/truncate-utf8-bytes": {
@@ -1694,6 +1863,7 @@
       "version": "5.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha1-+SW6JoVRWFlNkHMTzt0UdsWWf2w=",
+      "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -1702,42 +1872,34 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha1-JWtOGIK+feu/AdBfCqIDl3jqCAo=",
+      "version": "8.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha1-Blflcf5vBvyxXKUO0f28tJXNFoY=",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha1-0PTvdpkF1CbhaI8+NDgambYLduU=",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha1-vBv5SphdxQOI1UqSWKxAXDyi/Ao=",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha1-TuAtXXJRVdrgBPaulcc+fvXZVmM=",
+      "version": "15.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha1-XEM0ObmleJ7rOAa70NqJqL1AuNc=",
+      "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/which": {
@@ -1762,9 +1924,10 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha1-tWuIq//eYnkcY5FwQAyT3LDJVHI=",
+      "version": "8.21.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha1-AS5BP8B0KZRRIbDBUxWMQ0MIaVE=",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1785,6 +1948,7 @@
       "version": "5.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha1-gr6blX96/az5YeWYDxvyJ8C/dnM=",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
@@ -1792,7 +1956,8 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs="
+      "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/Tasks/GooglePlayReleaseV4/package.json
+++ b/Tasks/GooglePlayReleaseV4/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@types/jsdom": "^21.1.7",
     "@types/mocha": "^9.0.0",
-    "@types/node": "24.10.0",
+    "@types/node": "^24.10.0",
     "azure-pipelines-task-lib": "^5.2.8",
     "glob": "^7.1.7",
     "googleapis": "^90.0.0",

--- a/Tasks/GooglePlayReleaseV4/package.json
+++ b/Tasks/GooglePlayReleaseV4/package.json
@@ -4,11 +4,11 @@
   "dependencies": {
     "@types/jsdom": "^21.1.7",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^24.10.0",
+    "@types/node": "24.10.0",
     "azure-pipelines-task-lib": "^5.2.8",
     "glob": "^7.1.7",
     "googleapis": "^90.0.0",
-    "jsdom": "26.1.0"
+    "jsdom": "27.4.0"
   },
   "devDependencies": {
     "typescript": "5.7.2"

--- a/Tasks/GooglePlayReleaseV4/task.json
+++ b/Tasks/GooglePlayReleaseV4/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "273",
+        "Minor": "276",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/GooglePlayReleaseV4/task.loc.json
+++ b/Tasks/GooglePlayReleaseV4/task.loc.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "273",
+    "Minor": "276",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vso-android-extension",
-  "version": "4.273.0",
+  "version": "4.276.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vso-android-extension",
-      "version": "4.273.0",
+      "version": "4.276.0",
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-android-extension",
-  "version": "4.273.0",
+  "version": "4.276.0",
   "description": "Provides build/release tasks that enable performing continuous delivery to the Google Play store from an automated VSTS build or release definition.",
   "repository": {
     "type": "git",

--- a/vsts-extension-google-play.json
+++ b/vsts-extension-google-play.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1.0,
     "id": "google-play",
     "name": "Google Play",
-    "version": "4.273.0",
+    "version": "4.276.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for continuous delivery to the Google Play Store from TFS/Team Services build or release definitions",
     "categories": [


### PR DESCRIPTION
**Attached related issue:** (Y/N) [AB#2432159](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2432159)

**Task name**: GooglePlayReleaseV4

**Description**: 
- ws package a dependency coming through jsdom is marked vulnerable
- Ticket recommendation:  `Upgrade ws from 8.18.3 to 8.21.0 to fix the vulnerability.`
- This is a major version change from v26 to v27

Changes to major version of JSDOM can be seen here: https://github.com/jsdom/jsdom/releases/tag/v27.0.0
Primary change is minimum node version is now Node v20

**jsdom usage in task**:
- Single place in [metadatahelpers line 25](https://github.com/microsoft/google-play-vsts-extension/blob/d2cb20ff3261b2348dab939783ad89ba935ced9d/Tasks/GooglePlayReleaseV4/modules/metadataHelper.ts#L25)

**Verification**:
<img width="932" height="196" alt="image" src="https://github.com/user-attachments/assets/53561bbf-f75c-4ac0-8d69-270124a8ae96" />


**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) 
Testing done was primarily through the CI Checks through pipelines.
No additional testing or test cases executed


**Additional Info**
- This PR and the PR https://github.com/microsoft/google-play-vsts-extension/pull/499 will be bundled as v4.276.0 extension and released
- 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
