### PR TITLE
Route TfxInstaller through CFS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,37 @@ extends:
             Contents: '*.vsix'
             TargetFolder: $(System.ArtifactsDirectory)
 
+    - stage: ValidateTfxInstallerCFS
+      displayName: Validate TfxInstaller CFS routing
+      trigger: manual
+      dependsOn: BuildAndTest
+      jobs:
+      - job: ValidateTfxInstallerCFSJob
+        displayName: Install tfx-cli without publishing
+        steps:
+          - checkout: self
+
+          - task: UseNode@1
+            displayName: 'Install Node.js'
+            inputs:
+              version: '20.19.4'
+
+          - task: NpmAuthenticate@0
+            displayName: Authenticate npm feed
+            inputs:
+              workingFile: .npmrc
+
+          - task: TfxInstaller@5
+            displayName: Install tfx-cli through CFS
+            inputs:
+              version: 'v0.21.1'
+            env:
+              NPM_CONFIG_REGISTRY: https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/
+              NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
+
+          - script: tfx --version
+            displayName: Verify tfx-cli installation
+
     - stage: TestPublishToMarketplace
       trigger: manual      
       jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,6 +111,8 @@ extends:
       - job: PublishMarketplateJob
         displayName: Test - Publish to private Marketplace
         steps:
+          - checkout: self
+
           - download: current
             artifact: vsix
             displayName: Download Signed Artifact
@@ -120,9 +122,17 @@ extends:
             inputs:
               version: '20.19.4'
 
+          - task: NpmAuthenticate@0
+            displayName: Authenticate npm feed
+            inputs:
+              workingFile: .npmrc
+
           - task: TfxInstaller@5
             inputs:
               version: 'v0.21.1'
+            env:
+              NPM_CONFIG_REGISTRY: https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/
+              NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
           - task: 1ES.PublishAzureDevOpsExtension@1
             displayName: 'Publish the dev private extension to ms-vsclient'
@@ -141,6 +151,8 @@ extends:
       - job: PublishMarketplateJob
         displayName: Prod - Publish to Marketplace
         steps:
+          - checkout: self
+
           - download: current
             artifact: vsix
             displayName: Download Signed Artifact
@@ -150,9 +162,17 @@ extends:
             inputs:
               version: '20.19.4'
 
+          - task: NpmAuthenticate@0
+            displayName: Authenticate npm feed
+            inputs:
+              workingFile: .npmrc
+
           - task: TfxInstaller@5
             inputs:
               version: 'v0.21.1'
+            env:
+              NPM_CONFIG_REGISTRY: https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/
+              NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
           - task: 1ES.PublishAzureDevOpsExtension@1
             displayName: 'Publish the production extension to ms-vsclient'


### PR DESCRIPTION
## Summary
- authenticate the CFS `.npmrc` in both marketplace publish stages
- force `TfxInstaller@5` to install through `PipelineTools_PublicPackages`
- explicitly check out the repository before npm authentication

Tracks IcM 840111479 / pipeline 20704 (`CFSClean`).

## Validation
- pipeline YAML parses successfully
- explicit npm user config resolves to `PipelineTools_PublicPackages`