### PR TITLE
Add CFSClean network isolation policies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
+      networkIsolationPolicy: Monitored.Unrestricted,CFSClean,CFSClean2,CFSClean3,GitHub
     sdl:
       sourceAnalysisPool:
         name: 1ESPtTfsAgentBuildPoolSDL

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool:
         name: 1ESPtTfsAgentBuildPoolSDL

--- a/pr-check.yml
+++ b/pr-check.yml
@@ -18,7 +18,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
+      networkIsolationPolicy: Monitored.Unrestricted,CFSClean,CFSClean2,CFSClean3,GitHub
     sdl:
       sourceAnalysisPool:
         name: 1ESPtTfsAgentBuildPoolSDL

--- a/pr-check.yml
+++ b/pr-check.yml
@@ -17,6 +17,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool:
         name: 1ESPtTfsAgentBuildPoolSDL


### PR DESCRIPTION
## Summary
- configure the 1ES network isolation policy for the official pipeline
- configure the same policy for PR validation
- allow `CFSClean`, `CFSClean2`, and `CFSClean3`

[AB#2438878](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2438878)

## Validation
- parsed both pipeline YAML files successfully